### PR TITLE
Match Matter devices to Thread mesh by ext_address instead of position

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -159,6 +159,23 @@ An earlier reading of this blamed cached `GeneralDiagnostics.NetworkInterfaces`
 attributes being unreliable for sleepy end devices. That was wrong - matter-server
 was reporting the device correctly the whole time.
 
+### Matter is now set up before this integration polls
+
+The identifier fix was necessary but not sufficient: restarts still produced a
+degraded first snapshot. The Matter integration finished setting up at
+`03:14:40` while this integration had already run its first poll, so no Matter
+device had an identity yet, and with a 180s interval that snapshot stood for
+three minutes before the next poll corrected it. Once Matter is up, every node
+answers - `Matter diagnostics: 15/15 node(s) reported`.
+
+`after_dependencies: ["matter"]` in the manifest is Home Assistant's mechanism
+for exactly this, and is the right one here rather than `dependencies`: Matter
+is optional enrichment and the integration must still load without it.
+
+A node's last known identity is also remembered now. A MAC and a radio are
+stable facts, so a node that misses one update no longer drops its extended
+address and take every name matched from it off the map.
+
 ### Matter identity now comes from matter-server, not cached cluster attributes
 
 Independently worth doing, and done at the same time. `_get_matter_devices`

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -100,11 +100,32 @@ the label changed run to run as ordering shifted. Unidentified nodes are now
 named after their own address (`Thread Router 197B`) with manufacturer
 `Unknown`; `custom_routers.yaml` remains the way to supply a real name.
 
-### Known follow-ups, deliberately out of scope
+### The "13 Matter Thread devices vs 3 mesh nodes" gap, resolved
 
-- `_match_end_device` still matches children positionally. The JSON:API
-  `children[]` array carries each child's real extended address, which would
-  make that matching exact.
-- Home Assistant knows 13 Matter Thread devices while the mesh crawl reports
-  3 nodes. Unexplained; may need the `deviceCount` / `maxAge` crawl parameters
-  revisited, or those devices may simply be offline.
+The mesh crawl was right; the Matter count was wrong.
+
+Transport was guessed from strings: `"wifi" in model`, plus a three-name
+manufacturer allowlist, defaulting to Thread. TP-Link's model reads "Smart
+**Wi-Fi** Dimmer Switch" - hyphenated, so the test never fired - and Leedarson,
+Sciener and Shelly are not in the allowlist. Every Matter device therefore
+defaulted to Thread, giving "13 Thread + 0 Wi-Fi" against a true split of 5 and
+8. Of those 5 Thread devices only 2 were online, which together with the OTBR
+is exactly the 3 nodes the crawl reported.
+
+Transport now comes from the node's own `GeneralDiagnostics.NetworkInterfaces`
+interface type. The string heuristic survives only as a fallback for nodes that
+report no interfaces, and it can no longer return "thread" - an honest
+"unknown" keeps a device out of the topology rather than inventing a place for
+it in the mesh.
+
+That misclassification also fed the child matcher, which handed out "the next
+unclaimed Thread device" positionally and so labelled the border router's child
+as a Leedarson Wi-Fi bulb that was offline at the time. Children are now matched
+on identity only - extended address, else shared IPv6 - and an unidentifiable
+child is left unnamed. Verified against the live network: matter-server reports
+the real child's MAC as `0a:79:9b:2b:d2:12:3f:8f`, matching the extended
+address OTBR reports for it exactly.
+
+Device names now prefer `name_by_user` over `name`, so renames made in Home
+Assistant are respected. Both of this network's air quality monitors carry the
+same factory name, which made the map ambiguous about which one it was showing.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -79,6 +79,17 @@ Also fixed along the way: the polled border router now honours
 `custom_routers.yaml` instead of being hardcoded to "SkyConnect (OTBR)", and
 the SVG write moved off the event loop.
 
+### Fixed after the first deployment
+
+Restarting Home Assistant put the entry into `setup_retry` with
+`list index out of range`. `get_matter()` indexes into `hass.data["matter"]`,
+which is still empty if the Matter integration has not finished setting up, and
+`_get_matter_devices` caught `KeyError, StopIteration, AttributeError,
+ImportError` but not `IndexError` - so a race over what is only optional
+enrichment failed the entire update. It self-healed on retry, but recurred
+whenever Matter lost the race. `IndexError` is now caught, with a test that
+reproduces the original failure.
+
 ### Known follow-ups, deliberately out of scope
 
 - `_match_end_device` still matches children positionally. The JSON:API

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,6 +1,6 @@
 # PROJECT CHARTER — thread_topology / modern OTBR JSON:API
 
-Status: **awaiting sign-off** (created 2026-07-27)
+Status: **delivered and verified in production** (created and completed 2026-07-27)
 
 ## 1. What is the one thing this must do?
 
@@ -50,3 +50,40 @@ because `/node` now returns camelCase and `_process_topology` reads PascalCase.
    not everything collapsing to `end_device`.
 5. Update cycles complete without overlapping (task flow measured ~48 s).
 6. `pytest` green, including new tests driven by a real captured OTBR response.
+
+---
+
+## Outcome (2026-07-27)
+
+Delivered in `TeeJS/thread-topology` PR #2, merged as `622d30a`, deployed via
+HACS (`ddd858c` -> `622d30a`) after a full HA backup, and verified live.
+
+| Criterion | Result |
+|---|---|
+| 1. Entry `loaded` | Yes - first successful load since it was created |
+| 2. Network sensor | `ha-thread-0d68`, `router_count: 2` |
+| 3. Non-zero LQI | Both node sensors report `3` |
+| 4. One leader | `6a57f823187e197b`, the other node a `router` |
+| 5. No overlapping updates | Scan interval auto-raised 30s -> 180s |
+| 6. Tests green | 130 passing |
+
+The failure mode named in section 2 was real and would have shipped: the JS
+reference implementation this was ported from never requests the `mode` or
+`connectivity` diagnostic TLVs, because the visualizer draws edges from route
+data instead. Porting it faithfully would have produced loaded entities
+reporting LQI 0 for every node. `/node` had also silently moved to camelCase
+and renamed `NumOfRouter` to `routerCount`, which had been breaking leader
+detection, network name and router count independently of the 404.
+
+Also fixed along the way: the polled border router now honours
+`custom_routers.yaml` instead of being hardcoded to "SkyConnect (OTBR)", and
+the SVG write moved off the event loop.
+
+### Known follow-ups, deliberately out of scope
+
+- `_match_end_device` still matches children positionally. The JSON:API
+  `children[]` array carries each child's real extended address, which would
+  make that matching exact.
+- Home Assistant knows 13 Matter Thread devices while the mesh crawl reports
+  3 nodes. Unexplained; may need the `deviceCount` / `maxAge` crawl parameters
+  revisited, or those devices may simply be offline.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -90,6 +90,16 @@ enrichment failed the entire update. It self-healed on retry, but recurred
 whenever Matter lost the race. `IndexError` is now caught, with a test that
 reproduces the original failure.
 
+### Unidentified routers are no longer given invented vendors
+
+`_identify_router`'s last-resort fallback chose a name from a rotating list
+(`Eero`, `Google Nest`, `Apple HomePod`, `SmartThings`) by iteration order, so
+the first unrecognised router was labelled "Eero / Amazon-Eero" whatever it
+was. On this network that presented an IKEA air quality monitor as an Eero, and
+the label changed run to run as ordering shifted. Unidentified nodes are now
+named after their own address (`Thread Router 197B`) with manufacturer
+`Unknown`; `custom_routers.yaml` remains the way to supply a real name.
+
 ### Known follow-ups, deliberately out of scope
 
 - `_match_end_device` still matches children positionally. The JSON:API

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -100,6 +100,12 @@ the label changed run to run as ordering shifted. Unidentified nodes are now
 named after their own address (`Thread Router 197B`) with manufacturer
 `Unknown`; `custom_routers.yaml` remains the way to supply a real name.
 
+`BORDER_ROUTER_PATTERNS` was the other half of the same problem: it matched the
+bare substring `EA` anywhere in an extended address and called the result an
+Eero, which fits roughly one address in eighteen. Suffix matching is now
+anchored to the end of the address and the bare `EA` entry is gone, leaving only
+the specific `EA17` ending that the original comment actually described.
+
 ### The "13 Matter Thread devices vs 3 mesh nodes" gap, resolved
 
 The mesh crawl was right; the Matter count was wrong.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -135,3 +135,23 @@ address OTBR reports for it exactly.
 Device names now prefer `name_by_user` over `name`, so renames made in Home
 Assistant are respected. Both of this network's air quality monitors carry the
 same factory name, which made the map ambiguous about which one it was showing.
+
+### Matter identity now comes from matter-server, not cached cluster attributes
+
+Making the above honest exposed the layer underneath. `_get_matter_devices`
+read each node's MAC and radio from cached
+`GeneralDiagnostics.NetworkInterfaces` attributes, with a comment explaining
+that it did so to stay synchronous. For battery powered sleepy end devices that
+attribute is unreliable - absent after a restart, intermittent afterwards - so
+the extended address came and went, and every name matched from it went with
+it. The child of the border router flickered between its real name and nothing,
+and after one restart the whole Matter count sat at "0 Thread" for minutes.
+matter-server's `node_diagnostics()` had the data the entire time; it is what
+Home Assistant's own Matter device page shows.
+
+The method is now async - it is only ever called from `_async_update_data`,
+which already was - and awaits `matter_client.node_diagnostics()` per node,
+concurrently, each bounded by `MATTER_NODE_TIMEOUT` so an unreachable node
+cannot stall an update. That call returns `network_type` directly, so the radio
+is read rather than inferred, and the `chip.clusters` and `base64` imports are
+gone entirely.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -136,22 +136,36 @@ Device names now prefer `name_by_user` over `name`, so renames made in Home
 Assistant are respected. Both of this network's air quality monitors carry the
 same factory name, which made the map ambiguous about which one it was showing.
 
+### Why Matter device identity flickered between restarts
+
+Making the above honest exposed a bug that had been masked all along: Matter
+devices kept losing their identity from one restart to the next, so the child's
+name and the Thread device count changed for no visible reason.
+
+The cause was identifier selection. A Matter device carries more than one
+`matter` identifier - a `deviceid_<fabric>-<node>-MatterNodeDevice` and a
+`serial_<serial>` - and `device.identifiers` is a **set**. The code read
+whichever came out first and stopped. Python randomises string hashing per
+process, so a different identifier won on each start, and whenever the serial
+won there was no node id to parse, the device silently got no diagnostics, and
+every name and radio derived from it vanished. Only the `deviceid` form is
+parsed now, so a serial containing a dash cannot be mistaken for one either.
+
+Demonstrated rather than argued: with the old "first identifier wins" logic the
+tests fail under `PYTHONHASHSEED` 1, 5 and 6 and pass under 0, 2, 3, 4, 7, 8, 9
+and 12345. With the fix every seed passes.
+
+An earlier reading of this blamed cached `GeneralDiagnostics.NetworkInterfaces`
+attributes being unreliable for sleepy end devices. That was wrong - matter-server
+was reporting the device correctly the whole time.
+
 ### Matter identity now comes from matter-server, not cached cluster attributes
 
-Making the above honest exposed the layer underneath. `_get_matter_devices`
-read each node's MAC and radio from cached
-`GeneralDiagnostics.NetworkInterfaces` attributes, with a comment explaining
-that it did so to stay synchronous. For battery powered sleepy end devices that
-attribute is unreliable - absent after a restart, intermittent afterwards - so
-the extended address came and went, and every name matched from it went with
-it. The child of the border router flickered between its real name and nothing,
-and after one restart the whole Matter count sat at "0 Thread" for minutes.
-matter-server's `node_diagnostics()` had the data the entire time; it is what
-Home Assistant's own Matter device page shows.
-
-The method is now async - it is only ever called from `_async_update_data`,
-which already was - and awaits `matter_client.node_diagnostics()` per node,
-concurrently, each bounded by `MATTER_NODE_TIMEOUT` so an unreachable node
-cannot stall an update. That call returns `network_type` directly, so the radio
-is read rather than inferred, and the `chip.clusters` and `base64` imports are
-gone entirely.
+Independently worth doing, and done at the same time. `_get_matter_devices`
+read each node's MAC and radio from cached cluster attributes, with a comment
+explaining that it did so to stay synchronous. The method is now async - it is
+only ever called from `_async_update_data`, which already was - and awaits
+`matter_client.node_diagnostics()` per node, concurrently, each bounded by
+`MATTER_NODE_TIMEOUT` so an unreachable node cannot stall an update. That call
+returns `network_type` directly, so the radio is read rather than inferred, and
+the `chip.clusters` and `base64` imports are gone entirely.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,52 @@
+# PROJECT CHARTER — thread_topology / modern OTBR JSON:API
+
+Status: **awaiting sign-off** (created 2026-07-27)
+
+## 1. What is the one thing this must do?
+
+Home Assistant must expose **live Thread link-quality sensor entities** — one per
+mesh node, whose *state* is that node's LQI (0–3) — sourced from the OTBR at
+`192.168.1.144:8081`, updating on a schedule, usable in automations.
+
+## 2. What would be wrong if we shipped "working" software without it?
+
+The integration loading without error, entities appearing, and every
+`link_quality` reading **0** — because the JSON:API translator we are porting
+from the JS visualizer never emits `Connectivity`. Green config entry, dead
+sensors. That is the specific failure mode this charter exists to prevent.
+
+Second failure of the same kind: the network sensor showing
+`network_name: Unknown`, `router_count: 0`, and no node flagged as leader,
+because `/node` now returns camelCase and `_process_topology` reads PascalCase.
+
+## 3. What is explicitly off-limits as a workaround?
+
+- Shipping with `link_quality` hardcoded, defaulted, or derived from anything
+  other than real OTBR diagnostic data.
+- Dropping the legacy `/diagnostics` path. Auto-detect must keep working on
+  older OTBR builds.
+- Requiring the user to hand-edit files inside the HA container to deploy.
+  Deployment is HACS.
+- Widening scope into the SVG generator, sensor platform, or Matter matching.
+  The change is scoped to the **fetch layer + response key handling**.
+
+## 4. Deployment target and backup location
+
+- **Target:** HA Container `core-2026.7.4` at `192.168.1.25`, integration
+  installed via **HACS** from `TeeJS/thread-topology` (currently pinned to
+  commit `ddd858c`, tracking default branch). Deploy = commit → push → HACS
+  update → restart HA.
+- **Backup:** source is covered by git in this repo. Before the HACS update +
+  restart, take a **full HA backup** so the live `/config` state is recoverable.
+
+## 5. How will we verify it is done?
+
+1. Config entry `01KSBAQ2H0JE4QWQGR899FYM0B` reaches state `loaded`
+   (it has never once loaded since it was created 2026-05-23).
+2. `sensor.thread_network` reports `network_name = ha-thread-0d68`,
+   `router_count = 2` (not `Unknown` / `0`).
+3. At least one `ThreadNodeSensor` exists with a **non-zero** numeric LQI state.
+4. Exactly one node is flagged `role: leader`; others `router` / `end_device` —
+   not everything collapsing to `end_device`.
+5. Update cycles complete without overlapping (task flow measured ~48 s).
+6. `pytest` green, including new tests driven by a real captured OTBR response.

--- a/README.md
+++ b/README.md
@@ -106,10 +106,26 @@ For more complete examples including stats tiles and styled cards, see the [exam
 
 ## How It Works
 
-1. **OTBR API**: Fetches network data from `/node` and `/diagnostics` endpoints
+1. **OTBR API**: Fetches network data from the border router's REST API
 2. **Device Registry**: Queries Home Assistant's device registry for Matter devices
 3. **Smart Matching**: Maps Thread extended addresses to Matter device names
 4. **Transport Detection**: Identifies WiFi vs Thread based on device model/manufacturer
+
+### OTBR REST API versions
+
+ot-br-posix has two REST API generations, and the integration detects which one
+your border router serves:
+
+| | Legacy | Current (JSON:API) |
+|---|---|---|
+| Topology source | `GET /diagnostics` | task workflow via `/api/actions` |
+| Field naming | `PascalCase` | `camelCase`, JSON:API envelope |
+| Poll interval | 30s | 180s |
+
+Newer builds return 404 for `/diagnostics` and instead require posting a mesh
+crawl task, reading `/api/devices`, then requesting a network diagnostic per
+router. That crawl takes a minute or more, so when the JSON:API workflow is
+detected the scan interval is raised automatically to avoid overlapping polls.
 
 ## Supported Border Routers
 

--- a/custom_components/thread_topology/config_flow.py
+++ b/custom_components/thread_topology/config_flow.py
@@ -37,8 +37,15 @@ class ThreadTopologyConfigFlow(ConfigFlow, domain=DOMAIN):
                         timeout=aiohttp.ClientTimeout(total=10),
                     ) as response:
                         if response.status == 200:
-                            data = await response.json()
-                            network_name = data.get("NetworkName", "Thread Network")
+                            # OTBR serves this as application/json today, but
+                            # do not let a media type change break setup.
+                            data = await response.json(content_type=None)
+                            # Current builds renamed NetworkName to networkName.
+                            network_name = (
+                                data.get("networkName")
+                                or data.get("NetworkName")
+                                or "Thread Network"
+                            )
 
                             # Check if already configured
                             await self.async_set_unique_id(network_name)

--- a/custom_components/thread_topology/const.py
+++ b/custom_components/thread_topology/const.py
@@ -2,15 +2,78 @@
 
 DOMAIN = "thread_topology"
 
-# Default OTBR URL (inside HA container network)
+# Default OTBR URL (inside HA container network).
+# This is the Home Assistant *add-on* hostname. It is only a pre-filled default
+# in the config flow; deployments that run OTBR elsewhere (a separate host, a
+# reverse proxy) simply type their own URL.
 DEFAULT_OTBR_URL = "http://core-openthread-border-router:8081"
 
-# API endpoints
+# --- API endpoints ---------------------------------------------------------
+# ot-br-posix has two REST generations. The legacy one serves flat PascalCase
+# documents from /node and /diagnostics. The current one keeps /node (but with
+# camelCase keys) and replaces /diagnostics with a JSON:API task workflow.
 ENDPOINT_NODE = "/node"
 ENDPOINT_DIAGNOSTICS = "/diagnostics"
 
-# Update interval in seconds
+ENDPOINT_ACTIONS = "/api/actions"
+ENDPOINT_DEVICES = "/api/devices"
+ENDPOINT_API_DIAGNOSTICS = "/api/diagnostics"
+
+# JSON:API endpoints require this media type on both Accept and Content-Type,
+# and respond with it - aiohttp will not decode it as JSON unless we tell it to.
+CONTENT_TYPE_JSONAPI = "application/vnd.api+json"
+
+# Which REST generation the configured OTBR speaks. Probed once, then reused.
+API_MODE_UNKNOWN = "unknown"
+API_MODE_LEGACY = "legacy"
+API_MODE_JSONAPI = "jsonapi"
+
+# --- Update intervals ------------------------------------------------------
+# Update interval in seconds (legacy API: a single cheap GET).
 DEFAULT_SCAN_INTERVAL = 30
+
+# The JSON:API flow asks OTBR to crawl the entire mesh before diagnostics can
+# be read. Measured at 60s+ on a 3-device network, and it grows with mesh size,
+# so polling it every 30s would queue updates back-to-back forever.
+JSONAPI_SCAN_INTERVAL = 180
+
+# --- JSON:API task flow tuning ---------------------------------------------
+TASK_POLL_INTERVAL = 0.75
+TASK_TIMEOUT = 120
+REQUEST_TIMEOUT = 15
+
+# Attributes for the mesh crawl that populates /api/devices.
+DEVICE_COLLECTION_ATTRS = {
+    "maxAge": 30,
+    "maxRetries": 5,
+    "deviceCount": 50,
+    "timeout": 60,
+}
+
+# Network diagnostic TLVs to request per router.
+#
+# `mode` and `connectivity` are what make the link-quality sensors work:
+# link_quality is derived from Connectivity.LinkQuality1/2/3 and the router
+# role from Mode.DeviceType. Omitting them yields nodes that all report LQI 0
+# and classify as end devices.
+DIAGNOSTIC_TYPES = [
+    "extAddress",
+    "rloc16",
+    "mode",
+    "connectivity",
+    "route",
+    "leaderData",
+    "ipv6Addresses",
+    "childTable",
+    "children",
+    "routerNeighbors",
+]
+
+DIAGNOSTIC_TASK_TIMEOUT = 25
+
+# Roles in /api/devices worth asking for diagnostics. Some builds leave role
+# empty until the mesh crawl finishes, hence the fall back to all devices.
+ROUTING_ROLES = frozenset({"router", "leader", "borderrouter"})
 
 # Device types
 DEVICE_TYPE_ROUTER = "router"

--- a/custom_components/thread_topology/const.py
+++ b/custom_components/thread_topology/const.py
@@ -42,6 +42,10 @@ TASK_POLL_INTERVAL = 0.75
 TASK_TIMEOUT = 120
 REQUEST_TIMEOUT = 15
 
+# Per-node budget for matter-server diagnostics. That call reaches out over the
+# network, so an unreachable node must not be able to stall the whole update.
+MATTER_NODE_TIMEOUT = 10
+
 # Attributes for the mesh crawl that populates /api/devices.
 DEVICE_COLLECTION_ATTRS = {
     "maxAge": 30,

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -15,6 +15,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+# Optional import - Matter integration may not be loaded
+try:
+    from homeassistant.components.matter.helpers import get_matter
+    _MATTER_AVAILABLE = True
+except ImportError:
+    _MATTER_AVAILABLE = False
+
 from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -194,35 +201,131 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return await response.json()
 
     def _get_matter_devices(self) -> list[dict[str, Any]]:
-        """Get Matter devices from Home Assistant device registry."""
+        """Get Matter devices from Home Assistant device registry.
+
+        Also pulls each device's Thread Extended Address (EUI-64) and current
+        IPv6 addresses from matter-server's NodeDiagnostics, so that downstream
+        matching can use the actual hardware address instead of iteration order.
+        """
         device_registry = dr.async_get(self.hass)
         matter_devices = []
 
+        # Build {node_id: (mac_address, [ip_addresses])} from matter-server, if available.
+        # We read this synchronously from cached cluster attributes rather than
+        # calling the async client.node_diagnostics(), because we're in a sync method.
+        node_info_by_id: dict[int, tuple[str | None, list[str]]] = {}
+        if _MATTER_AVAILABLE:
+            try:
+                # Lazy-import here so this module still imports if Matter integration
+                # is missing optional deps in some HA setups.
+                import base64  # noqa: PLC0415
+                from chip.clusters import Objects as Clusters  # noqa: PLC0415
+
+                matter_adapter = get_matter(self.hass)
+                attribute = Clusters.GeneralDiagnostics.Attributes.NetworkInterfaces
+                thread_iface_type = (
+                    Clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum.kThread
+                )
+
+                for node in matter_adapter.matter_client.get_nodes():
+                    mac: str | None = None
+                    interfaces = node.get_attribute_value(
+                        0, cluster=None, attribute=attribute
+                    ) or []
+                    for iface in interfaces:
+                        # Find the operational Thread interface (or fall back to
+                        # any operational one if no Thread interface present).
+                        if not getattr(iface, "isOperational", True):
+                            continue
+                        hw_addr = getattr(iface, "hardwareAddress", None)
+                        if not hw_addr:
+                            continue
+                        # convert_mac_address logic: base64-decode if str, then
+                        # format as colon-separated hex.
+                        if isinstance(hw_addr, str):
+                            try:
+                                hw_addr = base64.b64decode(hw_addr)
+                            except (ValueError, TypeError):
+                                continue
+                        try:
+                            mac = ":".join(f"{b:02x}" for b in hw_addr)
+                        except (TypeError, ValueError):
+                            continue
+                        # Prefer the Thread interface if there is one; otherwise
+                        # take the first operational interface we find.
+                        if getattr(iface, "type", None) == thread_iface_type:
+                            break
+
+                    # IPs come from the same NetworkInterfaces struct.
+                    ips: list[str] = []
+                    for iface in interfaces:
+                        for ip_bytes in getattr(iface, "iPv6Addresses", []) or []:
+                            if isinstance(ip_bytes, str):
+                                try:
+                                    ip_bytes = base64.b64decode(ip_bytes)
+                                except (ValueError, TypeError):
+                                    continue
+                            # Format raw 16-byte IPv6 as standard string.
+                            if isinstance(ip_bytes, (bytes, bytearray)) and len(ip_bytes) == 16:
+                                import ipaddress  # noqa: PLC0415
+                                try:
+                                    ips.append(str(ipaddress.IPv6Address(bytes(ip_bytes))))
+                                except (ValueError, TypeError):
+                                    pass
+
+                    node_info_by_id[node.node_id] = (mac, ips)
+            except (KeyError, StopIteration, AttributeError, ImportError) as err:
+                _LOGGER.debug("Could not query Matter client for node diagnostics: %s", err)
+
         for device in device_registry.devices.values():
-            # Check if device has matter identifier
+            # Find the "matter" identifier on this device, if any.
+            matter_identifier_value: str | None = None
             for identifier in device.identifiers:
                 if identifier[0] == "matter":
-                    # Determine transport type based on model name
-                    model = (device.model or "").lower()
-                    manufacturer = (device.manufacturer or "").lower()
-                    name = device.name or "Unknown"
-
-                    # Detect WiFi vs Thread transport
-                    transport = "thread"  # Default to Thread
-                    if "wifi" in model or "wifi" in name.lower():
-                        transport = "wifi"
-                    elif manufacturer in ["nuki", "wemo", "lifx"]:
-                        # These typically use WiFi bridge for Matter
-                        transport = "wifi"
-
-                    matter_devices.append({
-                        "name": name,
-                        "model": device.model,
-                        "manufacturer": device.manufacturer,
-                        "identifiers": list(device.identifiers),
-                        "transport": transport,
-                    })
+                    matter_identifier_value = identifier[1]
                     break
+            if matter_identifier_value is None:
+                continue
+
+            # Determine transport type based on model name
+            model = (device.model or "").lower()
+            manufacturer = (device.manufacturer or "").lower()
+            name = device.name or "Unknown"
+
+            # Detect WiFi vs Thread transport
+            transport = "thread"  # Default to Thread
+            if "wifi" in model or "wifi" in name.lower():
+                transport = "wifi"
+            elif manufacturer in ["nuki", "wemo", "lifx"]:
+                transport = "wifi"
+
+            # Look up mac/IPs by parsing the node ID out of the Matter identifier.
+            # HA stores it as e.g. "deviceid_<fabric_hex>-<node_hex>-MatterNodeDevice".
+            mac_address: str | None = None
+            ip_addresses: list[str] = []
+            try:
+                # Strip the leading type prefix and split on dashes.
+                # node_id is the second hex segment.
+                stripped = matter_identifier_value
+                if stripped.startswith("deviceid_"):
+                    stripped = stripped[len("deviceid_"):]
+                parts = stripped.split("-")
+                if len(parts) >= 2:
+                    node_id = int(parts[1], 16)
+                    if node_id in node_info_by_id:
+                        mac_address, ip_addresses = node_info_by_id[node_id]
+            except (ValueError, IndexError):
+                pass
+
+            matter_devices.append({
+                "name": name,
+                "model": device.model,
+                "manufacturer": device.manufacturer,
+                "identifiers": list(device.identifiers),
+                "transport": transport,
+                "ext_address": _normalize_address(mac_address) if mac_address else None,
+                "ip_addresses": ip_addresses,
+            })
 
         return matter_devices
 
@@ -330,16 +433,43 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         }
 
     def _match_end_device(
-        self, parent_rloc: int, child_idx: int, matter_devices: list[dict]
+        self,
+        parent_rloc: int,
+        child_idx: int,
+        matter_devices: list[dict],
+        claimed_ext_addresses: set[str],
+        child_ip6_addresses: list[str] | None = None,
     ) -> dict[str, Any] | None:
-        """Try to match an end device with a Matter device."""
-        # Get Thread-only Matter devices
+        """Try to match an end device with a Matter device.
+
+        Strategy:
+          1. If we have child IPv6 addresses from OTBR, match by IP overlap with
+             any Matter device's known IPs.
+          2. Otherwise, return any unclaimed Thread Matter device (i.e., one
+             whose ext_address hasn't already been bound to a router/leader).
+             This is a fallback because OTBR's ChildTable response does not
+             include the child's ExtAddress.
+        """
         thread_devices = [d for d in matter_devices if d["transport"] == "thread"]
 
-        # Simple heuristic: assign devices based on order
-        # In a real implementation, you'd need to query Matter fabric data
-        if child_idx < len(thread_devices):
-            return thread_devices[child_idx]
+        # Try IP-based matching first if we have child IPs to check.
+        if child_ip6_addresses:
+            child_ip_set = {ip.lower() for ip in child_ip6_addresses}
+            for d in thread_devices:
+                if d.get("ext_address") and d["ext_address"] in claimed_ext_addresses:
+                    continue
+                for ip in d.get("ip_addresses", []):
+                    if ip.lower() in child_ip_set:
+                        return d
+
+        # Fallback: assign the next unclaimed Thread Matter device.
+        # Filter out anything already bound to a router/leader.
+        unclaimed = [
+            d for d in thread_devices
+            if not d.get("ext_address") or d["ext_address"] not in claimed_ext_addresses
+        ]
+        if child_idx < len(unclaimed):
+            return unclaimed[child_idx]
 
         return None
 
@@ -361,19 +491,31 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         thread_matter = [d for d in matter_devices if d["transport"] == "thread"]
         wifi_matter = [d for d in matter_devices if d["transport"] == "wifi"]
 
+        # Build a lookup table: normalized ext_address -> Matter device.
+        # This lets us match Thread mesh nodes to Matter devices by EUI-64
+        # instead of by iteration order (which is what the old code did).
+        matter_by_ext_addr: dict[str, dict] = {
+            d["ext_address"]: d for d in thread_matter if d.get("ext_address")
+        }
+
+        # Track which Matter devices we've already bound to a router/leader so
+        # we don't double-assign them when matching child end-devices.
+        claimed_ext_addresses: set[str] = set()
+
         # Build nodes dictionary
         nodes: dict[str, dict] = {}
-        thread_device_idx = 0
         router_index = 0
+        leader_ext_normalized = _normalize_address(leader_ext_address)
 
         for diag in diagnostics_data:
             ext_address = diag.get("ExtAddress", "")
+            ext_normalized = _normalize_address(ext_address)
             rloc16 = diag.get("Rloc16", 0)
 
             # Determine device role
             mode = diag.get("Mode", {})
             is_router = mode.get("DeviceType", 0) == 1
-            is_leader = ext_address == leader_ext_address
+            is_leader = ext_normalized == leader_ext_normalized
 
             if is_leader:
                 role = "leader"
@@ -382,10 +524,27 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 role = "end_device"
 
-            # Get router identification
+            # Try to match this router/leader to a Matter device by EUI-64.
+            # If found, that device's friendly name overrides the OUI-based
+            # router_info name (which only knows about a hardcoded list of OUIs).
+            matter_self_match = matter_by_ext_addr.get(ext_normalized)
+            if matter_self_match:
+                claimed_ext_addresses.add(ext_normalized)
+
+            # Get router identification (OUI lookup / custom_routers.yaml)
             router_info = self._identify_router(ext_address, is_leader, router_index)
             if role in ("leader", "router"):
                 router_index += 1
+
+            # Override OUI-based name with Matter device name if we matched.
+            if matter_self_match:
+                node_name = matter_self_match["name"]
+                node_manufacturer = (
+                    matter_self_match["manufacturer"] or router_info["manufacturer"]
+                )
+            else:
+                node_name = router_info["name"]
+                node_manufacturer = router_info["manufacturer"]
 
             # Get connectivity info
             connectivity = diag.get("Connectivity", {})
@@ -405,19 +564,27 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 link_quality = 0
 
-            # Get children and try to match with Matter devices
+            # Get children and try to match with Matter devices.
+            # We use the new ext_address-aware matcher; if the child is a
+            # Matter device whose mac_address we already collected, prefer
+            # that match. Otherwise fall back to the next unclaimed device.
             child_table = diag.get("ChildTable", [])
             children = []
-            for child in child_table:
+            for child_idx, child in enumerate(child_table):
                 child_id = child.get("ChildId", 0)
                 child_mode = child.get("Mode", {})
                 child_type = "sleepy" if child_mode.get("RxOnWhenIdle", 1) == 0 else "active"
 
-                # Try to match with a Matter device
-                matter_match = None
-                if thread_device_idx < len(thread_matter):
-                    matter_match = thread_matter[thread_device_idx]
-                    thread_device_idx += 1
+                # OTBR's standard ChildTable response usually omits the child's
+                # ExtAddress and IP list. Pass None for IPs unless present.
+                child_ip_list = child.get("IP6AddressList") or None
+
+                matter_match = self._match_end_device(
+                    rloc16, child_idx, matter_devices,
+                    claimed_ext_addresses, child_ip_list,
+                )
+                if matter_match and matter_match.get("ext_address"):
+                    claimed_ext_addresses.add(matter_match["ext_address"])
 
                 child_info = {
                     "id": child_id,
@@ -450,8 +617,8 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "ext_address": ext_address,
                 "rloc16": rloc16,
                 "role": role,
-                "name": router_info["name"],
-                "manufacturer": router_info["manufacturer"],
+                "name": node_name,
+                "manufacturer": node_manufacturer,
                 "device_type": router_info["type"],
                 "icon": router_info.get("icon", "router"),
                 "link_quality": link_quality,
@@ -461,6 +628,28 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "connections": connections,
                 "ip_addresses": diag.get("IP6AddressList", []),
             }
+
+        # Surface any Matter Thread devices we never matched to the mesh,
+        # so they show up in the visualizer as "offline" rather than just
+        # disappearing. Old code did this implicitly via positional matching;
+        # we make it explicit.
+        unmatched_thread = [
+            d for d in thread_matter
+            if d.get("ext_address") and d["ext_address"] not in claimed_ext_addresses
+        ]
+        # Also include Matter Thread devices with no ext_address known
+        # (e.g., matter-server hadn't populated diagnostics yet).
+        unmatched_thread.extend(
+            d for d in thread_matter if not d.get("ext_address")
+        )
+
+        # Log a summary so users can debug matching from HA logs.
+        _LOGGER.debug(
+            "Thread topology match summary: %d mesh nodes, %d Thread Matter devices, "
+            "%d claimed by ext_address, %d unmatched",
+            len(nodes), len(thread_matter), len(claimed_ext_addresses),
+            len(unmatched_thread),
+        )
 
         return {
             "network_name": network_name,
@@ -473,6 +662,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "thread": thread_matter,
                 "wifi": wifi_matter,
                 "total": len(matter_devices),
+                "unmatched_thread": unmatched_thread,
             },
             "known_routers": thread_routers,
         }

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -184,7 +184,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
 
             # Generate and save SVG to www folder
-            self.save_svg_to_www(topology)
+            await self.save_svg_to_www(topology)
 
             return topology
 
@@ -897,7 +897,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         svg += '</svg>'
         return svg
 
-    def save_svg_to_www(self, topology: dict[str, Any]) -> str | None:
+    async def save_svg_to_www(self, topology: dict[str, Any]) -> str | None:
         """Generate SVG and save to www folder."""
         try:
             svg_content = self.generate_svg(topology)

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -108,9 +108,37 @@ BORDER_ROUTER_PATTERNS = [
 ]
 
 
+TRANSPORT_THREAD = "thread"
+TRANSPORT_WIFI = "wifi"
+TRANSPORT_UNKNOWN = "unknown"
+
+# Manufacturers whose Matter range is Wi-Fi only. Used only as a fallback when
+# the node itself has not told us which radio it is on.
+WIFI_ONLY_MANUFACTURERS = frozenset({"nuki", "wemo", "lifx"})
+
+# Product names spell it every which way; "wifi" alone misses "Wi-Fi", which is
+# how TP-Link's "Smart Wi-Fi Dimmer Switch" was being counted as a Thread device.
+_WIFI_NAME_HINTS = ("wi-fi", "wifi", "wi fi")
+
+
 def _normalize_address(address: str) -> str:
     """Normalize an extended address by stripping separators and uppercasing."""
     return address.replace(":", "").replace("-", "").replace(" ", "").upper()
+
+
+def _guess_transport(model: str | None, name: str | None, manufacturer: str | None) -> str:
+    """Guess a device's radio when its Matter node reported no interfaces.
+
+    Deliberately never returns "thread". Assuming Thread by default is what put
+    Wi-Fi bulbs into the mesh as Thread children; an honest "unknown" keeps them
+    out of the topology instead of inventing a place for them.
+    """
+    haystack = f"{model or ''} {name or ''}".lower()
+    if any(hint in haystack for hint in _WIFI_NAME_HINTS):
+        return TRANSPORT_WIFI
+    if (manufacturer or "").lower() in WIFI_ONLY_MANUFACTURERS:
+        return TRANSPORT_WIFI
+    return TRANSPORT_UNKNOWN
 
 
 # --- JSON:API -> legacy translation ----------------------------------------
@@ -693,12 +721,30 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 thread_iface_type = (
                     Clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum.kThread
                 )
+                wifi_iface_type = (
+                    Clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum.kWiFi
+                )
 
                 for node in matter_adapter.matter_client.get_nodes():
                     mac: str | None = None
                     interfaces = node.get_attribute_value(
                         0, cluster=None, attribute=attribute
                     ) or []
+
+                    # Which radio the node actually uses. This is the device's
+                    # own report, and the only trustworthy source - guessing it
+                    # from model names put Wi-Fi bulbs in the Thread mesh.
+                    transport: str | None = None
+                    for iface in interfaces:
+                        if not getattr(iface, "isOperational", True):
+                            continue
+                        iface_type = getattr(iface, "type", None)
+                        if iface_type == thread_iface_type:
+                            transport = TRANSPORT_THREAD
+                            break
+                        if iface_type == wifi_iface_type and transport is None:
+                            transport = TRANSPORT_WIFI
+
                     for iface in interfaces:
                         # Find the operational Thread interface (or fall back to
                         # any operational one if no Thread interface present).
@@ -740,7 +786,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                                 except (ValueError, TypeError):
                                     pass
 
-                    node_info_by_id[node.node_id] = (mac, ips)
+                    node_info_by_id[node.node_id] = (mac, ips, transport)
             # IndexError covers get_matter() indexing into hass.data["matter"]
             # before the Matter integration has finished setting up - a restart
             # race that would otherwise fail the whole update over what is only
@@ -760,22 +806,16 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if matter_identifier_value is None:
                 continue
 
-            # Determine transport type based on model name
-            model = (device.model or "").lower()
-            manufacturer = (device.manufacturer or "").lower()
-            name = device.name or "Unknown"
+            # Respect a name the user set in Home Assistant; device.name is the
+            # factory name, which is identical across two of the same product.
+            name = device.name_by_user or device.name or "Unknown"
 
-            # Detect WiFi vs Thread transport
-            transport = "thread"  # Default to Thread
-            if "wifi" in model or "wifi" in name.lower():
-                transport = "wifi"
-            elif manufacturer in ["nuki", "wemo", "lifx"]:
-                transport = "wifi"
-
-            # Look up mac/IPs by parsing the node ID out of the Matter identifier.
-            # HA stores it as e.g. "deviceid_<fabric_hex>-<node_hex>-MatterNodeDevice".
+            # Look up mac/IPs/transport by parsing the node ID out of the Matter
+            # identifier. HA stores it as e.g.
+            # "deviceid_<fabric_hex>-<node_hex>-MatterNodeDevice".
             mac_address: str | None = None
             ip_addresses: list[str] = []
+            node_transport: str | None = None
             try:
                 # Strip the leading type prefix and split on dashes.
                 # node_id is the second hex segment.
@@ -786,9 +826,14 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if len(parts) >= 2:
                     node_id = int(parts[1], 16)
                     if node_id in node_info_by_id:
-                        mac_address, ip_addresses = node_info_by_id[node_id]
+                        mac_address, ip_addresses, node_transport = node_info_by_id[node_id]
             except (ValueError, IndexError):
                 pass
+
+            # Prefer what the node reported; only guess if it told us nothing.
+            transport = node_transport or _guess_transport(
+                device.model, name, device.manufacturer
+            )
 
             matter_devices.append({
                 "name": name,
@@ -907,42 +952,47 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _match_end_device(
         self,
-        parent_rloc: int,
-        child_idx: int,
         matter_devices: list[dict],
         claimed_ext_addresses: set[str],
+        child_ext_address: str | None = None,
         child_ip6_addresses: list[str] | None = None,
     ) -> dict[str, Any] | None:
         """Try to match an end device with a Matter device.
 
-        Strategy:
-          1. If we have child IPv6 addresses from OTBR, match by IP overlap with
-             any Matter device's known IPs.
-          2. Otherwise, return any unclaimed Thread Matter device (i.e., one
-             whose ext_address hasn't already been bound to a router/leader).
-             This is a fallback because OTBR's ChildTable response does not
-             include the child's ExtAddress.
-        """
-        thread_devices = [d for d in matter_devices if d["transport"] == "thread"]
+        Matching is on identity only - the child's extended address, or failing
+        that an overlap between its IPv6 addresses and a Matter device's. If
+        neither identifies it, the child stays unnamed.
 
-        # Try IP-based matching first if we have child IPs to check.
+        There used to be a positional fallback here that handed out "the next
+        unclaimed Thread device", which is how a Wi-Fi bulb ended up labelled as
+        a Thread child of the border router. Current OTBR builds report each
+        child's extended address, so the guess is no longer needed, and an
+        unnamed child beats a confidently wrong one.
+        """
+        thread_devices = [
+            d for d in matter_devices if d["transport"] == TRANSPORT_THREAD
+        ]
+
+        def unclaimed(device: dict) -> bool:
+            ext = device.get("ext_address")
+            return not ext or ext not in claimed_ext_addresses
+
+        # Exact match on the child's own extended address.
+        if child_ext_address:
+            wanted = _normalize_address(child_ext_address)
+            for device in thread_devices:
+                if device.get("ext_address") == wanted and unclaimed(device):
+                    return device
+
+        # Otherwise match on a shared IPv6 address.
         if child_ip6_addresses:
             child_ip_set = {ip.lower() for ip in child_ip6_addresses}
-            for d in thread_devices:
-                if d.get("ext_address") and d["ext_address"] in claimed_ext_addresses:
+            for device in thread_devices:
+                if not unclaimed(device):
                     continue
-                for ip in d.get("ip_addresses", []):
+                for ip in device.get("ip_addresses", []):
                     if ip.lower() in child_ip_set:
-                        return d
-
-        # Fallback: assign the next unclaimed Thread Matter device.
-        # Filter out anything already bound to a router/leader.
-        unclaimed = [
-            d for d in thread_devices
-            if not d.get("ext_address") or d["ext_address"] not in claimed_ext_addresses
-        ]
-        if child_idx < len(unclaimed):
-            return unclaimed[child_idx]
+                        return device
 
         return None
 
@@ -965,8 +1015,10 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         leader_ext_address = local_ext_address
 
         # Separate Thread and WiFi Matter devices
-        thread_matter = [d for d in matter_devices if d["transport"] == "thread"]
-        wifi_matter = [d for d in matter_devices if d["transport"] == "wifi"]
+        # Devices whose radio we could not determine land in neither bucket -
+        # counting them as Thread is what inflated the mesh device count.
+        thread_matter = [d for d in matter_devices if d["transport"] == TRANSPORT_THREAD]
+        wifi_matter = [d for d in matter_devices if d["transport"] == TRANSPORT_WIFI]
 
         # Build a lookup table: normalized ext_address -> Matter device.
         # This lets us match Thread mesh nodes to Matter devices by EUI-64
@@ -1046,24 +1098,26 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 link_quality = 0
 
-            # Get children and try to match with Matter devices.
-            # We use the new ext_address-aware matcher; if the child is a
-            # Matter device whose mac_address we already collected, prefer
-            # that match. Otherwise fall back to the next unclaimed device.
+            # Get children and try to match with Matter devices. Matching is on
+            # identity - the child's own extended address where OTBR reports it,
+            # otherwise a shared IPv6 address. A child we cannot identify is
+            # left unnamed rather than assigned a plausible-looking device.
             child_table = diag.get("ChildTable", [])
             children = []
-            for child_idx, child in enumerate(child_table):
+            for child in child_table:
                 child_id = child.get("ChildId", 0)
                 child_mode = child.get("Mode", {})
                 child_type = "sleepy" if child_mode.get("RxOnWhenIdle", 1) == 0 else "active"
 
-                # OTBR's standard ChildTable response usually omits the child's
-                # ExtAddress and IP list. Pass None for IPs unless present.
+                # Legacy OTBR omits both of these; current builds report the
+                # extended address in the children[] array.
                 child_ip_list = child.get("IP6AddressList") or None
 
                 matter_match = self._match_end_device(
-                    rloc16, child_idx, matter_devices,
-                    claimed_ext_addresses, child_ip_list,
+                    matter_devices,
+                    claimed_ext_addresses,
+                    child.get("ExtAddress"),
+                    child_ip_list,
                 )
                 if matter_match and matter_match.get("ext_address"):
                     claimed_ext_addresses.add(matter_match["ext_address"])

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -1383,19 +1383,28 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         svg += '</svg>'
         return svg
 
+    def _write_svg(self, svg_content: str) -> str:
+        """Write the SVG to the www folder. Runs in an executor thread."""
+        www_path = self.hass.config.path("www")
+        os.makedirs(www_path, exist_ok=True)
+
+        svg_path = os.path.join(www_path, "thread_topology.svg")
+        with open(svg_path, "w", encoding="utf-8") as f:
+            f.write(svg_content)
+
+        return svg_path
+
     async def save_svg_to_www(self, topology: dict[str, Any]) -> str | None:
         """Generate SVG and save to www folder."""
         try:
             svg_content = self.generate_svg(topology)
-            www_path = self.hass.config.path("www")
 
-            # Create www folder if it doesn't exist
-            if not os.path.exists(www_path):
-                os.makedirs(www_path)
-
-            svg_path = os.path.join(www_path, "thread_topology.svg")
-            with open(svg_path, "w", encoding="utf-8") as f:
-                f.write(svg_content)
+            # Creating directories and writing the file blocks; doing it inline
+            # stalls the event loop on every update and Home Assistant logs a
+            # warning asking for a bug report.
+            svg_path = await self.hass.async_add_executor_job(
+                self._write_svg, svg_content
+            )
 
             _LOGGER.debug("SVG saved to %s", svg_path)
             return "/local/thread_topology.svg"

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from datetime import timedelta
@@ -23,15 +24,34 @@ except ImportError:
     _MATTER_AVAILABLE = False
 
 from .const import (
+    API_MODE_JSONAPI,
+    API_MODE_LEGACY,
+    API_MODE_UNKNOWN,
+    CONTENT_TYPE_JSONAPI,
     DEFAULT_SCAN_INTERVAL,
+    DEVICE_COLLECTION_ATTRS,
+    DIAGNOSTIC_TASK_TIMEOUT,
+    DIAGNOSTIC_TYPES,
     DOMAIN,
+    ENDPOINT_ACTIONS,
+    ENDPOINT_API_DIAGNOSTICS,
+    ENDPOINT_DEVICES,
     ENDPOINT_DIAGNOSTICS,
     ENDPOINT_NODE,
+    JSONAPI_SCAN_INTERVAL,
+    REQUEST_TIMEOUT,
+    ROUTING_ROLES,
+    TASK_POLL_INTERVAL,
+    TASK_TIMEOUT,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 CUSTOM_ROUTERS_FILE = "custom_routers.yaml"
+
+
+class OtbrTaskError(Exception):
+    """A JSON:API diagnostic task failed, was stopped, or timed out."""
 
 # Known Thread Border Router OUI prefixes (first 6 chars of extended address)
 # These are based on IEEE OUI database and known devices
@@ -93,6 +113,267 @@ def _normalize_address(address: str) -> str:
     return address.replace(":", "").replace("-", "").replace(" ", "").upper()
 
 
+# --- JSON:API -> legacy translation ----------------------------------------
+#
+# Current ot-br-posix builds return camelCase fields wrapped in a JSON:API
+# envelope. Everything downstream of the fetch layer (_process_topology, the
+# sensors, the SVG) reads the legacy flat PascalCase shape, so we translate on
+# the way in rather than touching all of it.
+#
+# The translation is not purely a case change:
+#   * Rloc16 is a hex string ("0xf800") here, an int in the legacy API. The
+#     downstream code does arithmetic on it, so it must come out as an int.
+#   * Mode.FullThreadDevice was renamed deviceTypeFTD, and legacy Mode flags
+#     are 0/1 ints rather than booleans.
+#   * /node renamed NumOfRouter to routerCount outright.
+
+
+def _parse_rloc(value: Any) -> int | None:
+    """Parse an RLOC16 given as an int or a hex string like '0xf800'."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return int(text, 16)
+    except ValueError:
+        return None
+
+
+def _first(mapping: dict, *names: str, default: Any = None) -> Any:
+    """Return the first present, non-None value among `names`."""
+    for name in names:
+        if mapping.get(name) is not None:
+            return mapping[name]
+    return default
+
+
+def _link_margin_to_lqi(margin: Any) -> int:
+    """Map a link margin in dB to OpenThread's 0-3 link quality scale."""
+    if not isinstance(margin, (int, float)):
+        return 0
+    if margin >= 20:
+        return 3
+    if margin >= 10:
+        return 2
+    if margin >= 2:
+        return 1
+    return 0
+
+
+def _translate_mode(mode: Any) -> dict[str, int]:
+    """Translate a JSON:API mode object into the legacy Mode shape."""
+    if not isinstance(mode, dict):
+        return {}
+
+    def flag(*names: str) -> int:
+        value = _first(mode, *names)
+        return int(bool(value))
+
+    return {
+        "RxOnWhenIdle": flag("rxOnWhenIdle", "RxOnWhenIdle"),
+        "DeviceType": flag("deviceTypeFTD", "fullThreadDevice", "DeviceType"),
+        "NetworkData": flag("fullNetworkData", "NetworkData"),
+    }
+
+
+def _translate_connectivity(connectivity: Any) -> dict[str, int]:
+    """Translate a JSON:API connectivity object into the legacy shape.
+
+    This is what the per-node link quality sensors are built from.
+    """
+    if not isinstance(connectivity, dict):
+        return {}
+
+    def num(*names: str) -> int:
+        value = _first(connectivity, *names, default=0)
+        return int(value) if isinstance(value, (int, float)) else 0
+
+    return {
+        "ParentPriority": num("parentPriority", "ParentPriority"),
+        "LinkQuality3": num("linkQuality3", "LinkQuality3"),
+        "LinkQuality2": num("linkQuality2", "LinkQuality2"),
+        "LinkQuality1": num("linkQuality1", "LinkQuality1"),
+        "LeaderCost": num("leaderCost", "LeaderCost"),
+        "IdSequence": num("idSequence", "IdSequence"),
+        "ActiveRouters": num("activeRouters", "ActiveRouters"),
+    }
+
+
+def _translate_route_data(attributes: dict) -> list[dict]:
+    """Build the legacy Route.RouteData list.
+
+    Prefers the real route table. Some builds return only routerNeighbors, in
+    which case we synthesize equivalent entries with link quality derived from
+    the neighbour's link margin.
+    """
+    route = attributes.get("route")
+    entries = route.get("routeData") if isinstance(route, dict) else None
+
+    if isinstance(entries, list):
+        return [
+            {
+                "RouteId": _first(entry, "routeId", "RouteId", default=0),
+                "LinkQualityIn": _first(entry, "linkQualityIn", "LinkQualityIn", default=0),
+                "LinkQualityOut": _first(entry, "linkQualityOut", "LinkQualityOut", default=0),
+                "RouteCost": _first(entry, "routeCost", "RouteCost", default=0),
+            }
+            for entry in entries
+            if isinstance(entry, dict)
+        ]
+
+    neighbors = attributes.get("routerNeighbors")
+    if not isinstance(neighbors, list):
+        return []
+
+    route_data = []
+    for neighbor in neighbors:
+        if not isinstance(neighbor, dict):
+            continue
+        peer_rloc = _parse_rloc(_first(neighbor, "rloc16", "addr"))
+        lqi = _link_margin_to_lqi(neighbor.get("linkMargin"))
+        route_data.append({
+            "RouteId": (peer_rloc >> 10) if peer_rloc is not None else 0,
+            "LinkQualityIn": lqi,
+            "LinkQualityOut": lqi,
+            "RouteCost": 0,
+        })
+    return route_data
+
+
+def _translate_child_table(attributes: dict) -> list[dict]:
+    """Build the legacy ChildTable from the childTable and children arrays.
+
+    Both may be present and they carry different fields: childTable mirrors the
+    legacy TLV, while children additionally exposes each child's extended
+    address and RLOC16. We merge them by child id, letting childTable win on
+    fields they share.
+    """
+    rows: dict[Any, dict] = {}
+    order: list[Any] = []
+
+    for source in ("children", "childTable"):
+        entries = attributes.get(source)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+
+            rloc = _parse_rloc(entry.get("rloc16"))
+            child_id = entry.get("childId")
+            if child_id is None and rloc is not None:
+                child_id = rloc & 0x1FF
+
+            key = child_id if child_id is not None else f"#{len(order)}"
+            row = rows.get(key)
+            if row is None:
+                row = {"ChildId": child_id if child_id is not None else 0}
+                rows[key] = row
+                order.append(key)
+
+            # In children[] the mode flags sit at the top level; in
+            # childTable[] they are nested under "mode".
+            mode_src = entry.get("mode") if isinstance(entry.get("mode"), dict) else entry
+            translated_mode = _translate_mode(mode_src)
+            if translated_mode:
+                row["Mode"] = translated_mode
+
+            if isinstance(entry.get("timeout"), int):
+                row["Timeout"] = entry["timeout"]
+            if isinstance(entry.get("linkQuality"), int):
+                row["LinkQuality"] = entry["linkQuality"]
+            if entry.get("extAddress"):
+                row["ExtAddress"] = entry["extAddress"]
+            if rloc is not None:
+                row["Rloc16"] = rloc
+            addresses = entry.get("ipv6Addresses")
+            if isinstance(addresses, list) and addresses:
+                row["IP6AddressList"] = addresses
+
+    return [rows[key] for key in order]
+
+
+def _translate_diagnostic(item: Any) -> dict[str, Any]:
+    """Convert one JSON:API networkDiagnostics item to the legacy flat shape."""
+    attributes = item.get("attributes") if isinstance(item, dict) else None
+    if not isinstance(attributes, dict):
+        return {}
+
+    rloc = _parse_rloc(attributes.get("rloc16"))
+    result: dict[str, Any] = {
+        "ExtAddress": attributes.get("extAddress", ""),
+        "Rloc16": rloc if rloc is not None else 0,
+        "IP6AddressList": attributes.get("ipv6Addresses") or [],
+    }
+
+    mode = _translate_mode(attributes.get("mode"))
+    if mode:
+        result["Mode"] = mode
+
+    connectivity = _translate_connectivity(attributes.get("connectivity"))
+    if connectivity:
+        result["Connectivity"] = connectivity
+
+    route_data = _translate_route_data(attributes)
+    if route_data:
+        result["Route"] = {"RouteData": route_data}
+
+    child_table = _translate_child_table(attributes)
+    if child_table:
+        result["ChildTable"] = child_table
+
+    if attributes.get("leaderData"):
+        result["LeaderData"] = attributes["leaderData"]
+
+    # Authoritative leader flag - far better than inferring the leader from
+    # whichever node happens to be the OTBR we are talking to.
+    if attributes.get("isLeader") is not None:
+        result["IsLeader"] = bool(attributes["isLeader"])
+    if attributes.get("isBorderRouter") is not None:
+        result["IsBorderRouter"] = bool(attributes["isBorderRouter"])
+
+    return result
+
+
+# /node kept its route but renamed its fields; NumOfRouter became routerCount.
+_NODE_FIELD_ALIASES = {
+    "ExtAddress": ("ExtAddress", "extAddress"),
+    "NetworkName": ("NetworkName", "networkName"),
+    "NumOfRouter": ("NumOfRouter", "routerCount"),
+    "State": ("State", "state"),
+    "Rloc16": ("Rloc16", "rloc16"),
+    "LeaderData": ("LeaderData", "leaderData"),
+    "ExtPanId": ("ExtPanId", "extPanId"),
+    "RlocAddress": ("RlocAddress", "rlocAddress"),
+}
+
+
+def _translate_node(node_data: Any) -> dict[str, Any]:
+    """Normalize a /node response to the legacy PascalCase key names.
+
+    Original keys are preserved; canonical ones are added alongside, so this is
+    a no-op on OTBR builds that already speak PascalCase.
+    """
+    if not isinstance(node_data, dict):
+        return {}
+
+    result = dict(node_data)
+    for canonical, aliases in _NODE_FIELD_ALIASES.items():
+        value = _first(node_data, *aliases)
+        if value is not None:
+            result[canonical] = value
+
+    rloc = _parse_rloc(result.get("Rloc16"))
+    if rloc is not None:
+        result["Rloc16"] = rloc
+
+    return result
+
+
 class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to fetch Thread topology data from OTBR."""
 
@@ -113,6 +394,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._session: aiohttp.ClientSession | None = None
         self._router_index = 0  # Track router numbering
         self._custom_routers: list[dict[str, str]] = self._load_custom_routers()
+        self._api_mode = API_MODE_UNKNOWN
 
     def _load_custom_routers(self) -> list[dict[str, str]]:
         """Load user-defined border routers from custom_routers.yaml."""
@@ -166,11 +448,12 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Reset router index for each update
             self._router_index = 0
 
-            # Fetch node info
-            node_data = await self._fetch_endpoint(ENDPOINT_NODE)
+            # Fetch node info. Field names differ between REST generations, so
+            # normalize before anything downstream reads it.
+            node_data = _translate_node(await self._fetch_endpoint(ENDPOINT_NODE))
 
             # Fetch diagnostics (topology)
-            diagnostics_data = await self._fetch_endpoint(ENDPOINT_DIAGNOSTICS)
+            diagnostics_data = await self._fetch_diagnostics()
 
             # Get Matter devices from HA device registry
             matter_devices = self._get_matter_devices()
@@ -192,13 +475,197 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Error communicating with OTBR: {err}") from err
         except asyncio.TimeoutError as err:
             raise UpdateFailed(f"Timeout communicating with OTBR: {err}") from err
+        except OtbrTaskError as err:
+            raise UpdateFailed(f"OTBR diagnostic task failed: {err}") from err
 
     async def _fetch_endpoint(self, endpoint: str) -> Any:
         """Fetch data from a specific OTBR endpoint."""
         url = f"{self.otbr_url}{endpoint}"
-        async with self._session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as response:
+        async with self._session.get(
+            url, timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
+        ) as response:
             response.raise_for_status()
-            return await response.json()
+            # OTBR serves JSON:API routes as application/vnd.api+json, which
+            # aiohttp refuses to decode unless we stop it checking.
+            return await response.json(content_type=None)
+
+    # --- diagnostics fetching ----------------------------------------------
+
+    async def _fetch_diagnostics(self) -> list[dict[str, Any]]:
+        """Fetch mesh diagnostics, auto-detecting which REST API is served.
+
+        Legacy builds answer GET /diagnostics directly. Current builds return
+        404 there and require a JSON:API task workflow instead. We probe once
+        and remember, but re-probe if a legacy OTBR is later upgraded.
+        """
+        if self._api_mode != API_MODE_JSONAPI:
+            try:
+                data = await self._fetch_endpoint(ENDPOINT_DIAGNOSTICS)
+            except aiohttp.ClientResponseError as err:
+                if err.status != 404:
+                    raise
+                _LOGGER.info(
+                    "OTBR has no legacy /diagnostics endpoint (404); "
+                    "using the JSON:API task workflow"
+                )
+                self._set_api_mode(API_MODE_JSONAPI)
+            else:
+                self._set_api_mode(API_MODE_LEGACY)
+                return data if isinstance(data, list) else [data]
+
+        return await self._fetch_diagnostics_jsonapi()
+
+    def _set_api_mode(self, mode: str) -> None:
+        """Record which REST generation the OTBR speaks.
+
+        The JSON:API flow makes OTBR crawl the whole mesh, which takes longer
+        than the legacy poll interval, so stretch the interval to match.
+        """
+        if self._api_mode == mode:
+            return
+
+        self._api_mode = mode
+        _LOGGER.debug("OTBR API mode set to %s", mode)
+
+        if mode != API_MODE_JSONAPI:
+            return
+
+        slower = timedelta(seconds=JSONAPI_SCAN_INTERVAL)
+        if self.update_interval is not None and self.update_interval < slower:
+            _LOGGER.info(
+                "Raising scan interval to %ss: the JSON:API mesh crawl takes "
+                "longer than the configured %ss",
+                JSONAPI_SCAN_INTERVAL,
+                int(self.update_interval.total_seconds()),
+            )
+            self.update_interval = slower
+
+    async def _fetch_diagnostics_jsonapi(self) -> list[dict[str, Any]]:
+        """Run the three-step JSON:API diagnostic workflow."""
+        # 1. Ask OTBR to crawl the mesh, which is what populates /api/devices.
+        task_id = await self._post_action({
+            "type": "updateDeviceCollectionTask",
+            "attributes": DEVICE_COLLECTION_ATTRS,
+        })
+        await self._wait_for_task(task_id, "device collection")
+
+        # 2. Learn which devices are worth querying.
+        payload = await self._fetch_json(ENDPOINT_DEVICES)
+        devices = payload.get("data") or []
+        routers = [
+            device for device in devices
+            if str((device.get("attributes") or {}).get("role") or "").lower()
+            in ROUTING_ROLES
+        ]
+        if not routers:
+            # Some builds leave role empty until the crawl settles.
+            _LOGGER.debug("No routing-role devices reported; querying all %d", len(devices))
+            routers = devices
+
+        _LOGGER.debug("Device collection: %d total, %d routing", len(devices), len(routers))
+
+        # 3. Ask each router for its diagnostics, concurrently.
+        results = await asyncio.gather(
+            *(self._fetch_router_diagnostic(device) for device in routers)
+        )
+
+        diagnostics = [
+            translated
+            for item in results
+            if item and (translated := _translate_diagnostic(item))
+        ]
+
+        if not diagnostics:
+            raise OtbrTaskError(
+                f"no diagnostics returned by any of {len(routers)} device(s)"
+            )
+
+        _LOGGER.debug(
+            "Collected diagnostics from %d/%d router(s)", len(diagnostics), len(routers)
+        )
+        return diagnostics
+
+    async def _fetch_router_diagnostic(self, device: dict) -> dict | None:
+        """Request and collect one router's network diagnostic."""
+        device_id = device.get("id")
+        try:
+            task_id = await self._post_action({
+                "type": "getNetworkDiagnosticTask",
+                "attributes": {
+                    "destination": device_id,
+                    "types": DIAGNOSTIC_TYPES,
+                    "timeout": DIAGNOSTIC_TASK_TIMEOUT,
+                },
+            })
+            task = await self._wait_for_task(task_id, f"diagnostic {device_id}")
+
+            # The finished task points at the stored diagnostic document.
+            relationships = task.get("relationships") or {}
+            result_ref = (relationships.get("result") or {}).get("data") or {}
+            diagnostic_id = result_ref.get("id")
+            if not diagnostic_id:
+                _LOGGER.debug("Task for %s produced no diagnostic result", device_id)
+                return None
+
+            payload = await self._fetch_json(f"{ENDPOINT_API_DIAGNOSTICS}/{diagnostic_id}")
+            return payload.get("data")
+        except (aiohttp.ClientError, asyncio.TimeoutError, OtbrTaskError) as err:
+            # One unreachable router should not fail the whole update.
+            _LOGGER.debug("Skipping diagnostics for %s: %s", device_id, err)
+            return None
+
+    async def _fetch_json(self, endpoint: str) -> dict[str, Any]:
+        """GET a JSON:API endpoint."""
+        url = f"{self.otbr_url}{endpoint}"
+        async with self._session.get(
+            url,
+            headers={"Accept": CONTENT_TYPE_JSONAPI},
+            timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
+        ) as response:
+            response.raise_for_status()
+            return await response.json(content_type=None)
+
+    async def _post_action(self, task: dict[str, Any]) -> str:
+        """POST a task to /api/actions and return its id."""
+        url = f"{self.otbr_url}{ENDPOINT_ACTIONS}"
+        async with self._session.post(
+            url,
+            data=json.dumps({"data": [task]}),
+            headers={
+                "Accept": CONTENT_TYPE_JSONAPI,
+                "Content-Type": CONTENT_TYPE_JSONAPI,
+            },
+            timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
+        ) as response:
+            response.raise_for_status()
+            payload = await response.json(content_type=None)
+
+        data = payload.get("data")
+        items = data if isinstance(data, list) else [data]
+        if not items or not isinstance(items[0], dict) or not items[0].get("id"):
+            raise OtbrTaskError(f"{ENDPOINT_ACTIONS} returned no task id")
+        return items[0]["id"]
+
+    async def _wait_for_task(self, task_id: str, label: str) -> dict[str, Any]:
+        """Poll a task until it completes."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + TASK_TIMEOUT
+
+        while loop.time() < deadline:
+            await asyncio.sleep(TASK_POLL_INTERVAL)
+            try:
+                payload = await self._fetch_json(f"{ENDPOINT_ACTIONS}/{task_id}")
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                continue  # transient; try again on the next poll
+
+            item = payload.get("data") or payload
+            status = str((item.get("attributes") or {}).get("status") or "").lower()
+            if status == "completed":
+                return item
+            if status in ("stopped", "failed"):
+                raise OtbrTaskError(f"task '{label}' {status}")
+
+        raise OtbrTaskError(f"task '{label}' timed out after {TASK_TIMEOUT}s")
 
     def _get_matter_devices(self) -> list[dict[str, Any]]:
         """Get Matter devices from Home Assistant device registry.
@@ -353,21 +820,19 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return routers
 
     def _identify_router(
-        self, ext_address: str, is_leader: bool, router_index: int
+        self, ext_address: str, is_local_otbr: bool, router_index: int
     ) -> dict[str, str]:
-        """Identify a router by its extended address or characteristics."""
-        # Check if this is the OTBR leader (typically SkyConnect or similar)
-        if is_leader:
-            return {
-                "name": "SkyConnect (OTBR)",
-                "manufacturer": "Nabu Casa",
-                "type": "border_router",
-                "icon": "home-assistant",
-            }
+        """Identify a router by its extended address or characteristics.
 
+        `is_local_otbr` marks the border router this integration polls, which
+        is named directly rather than guessed at from its OUI. Note this is a
+        separate question from which node holds Thread leadership.
+        """
         ext_normalized = _normalize_address(ext_address)
 
-        # Check custom routers first (user-defined in custom_routers.yaml)
+        # Check custom routers first (user-defined in custom_routers.yaml).
+        # These take precedence over every built-in guess, including the name
+        # for the border router we poll - plenty of OTBRs are not SkyConnects.
         for custom in self._custom_routers:
             custom_addr = custom["address"]
             # Exact full match, OUI prefix match (first 6 hex chars), or substring
@@ -382,6 +847,15 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "type": "border_router",
                     "icon": custom.get("icon", "router"),
                 }
+
+        # The OTBR we talk to, if the user has not named it themselves
+        if is_local_otbr:
+            return {
+                "name": "SkyConnect (OTBR)",
+                "manufacturer": "Nabu Casa",
+                "type": "border_router",
+                "icon": "home-assistant",
+            }
 
         # Convert extended address to OUI format (XX:XX:XX)
         if len(ext_normalized) >= 6:
@@ -481,11 +955,15 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         thread_routers: list[dict],
     ) -> dict[str, Any]:
         """Process raw OTBR data into topology structure."""
-        # Get leader info
-        leader_ext_address = node_data.get("ExtAddress", "")
+        # /node describes the border router we are polling, which is not
+        # necessarily the Thread leader - it may well be a plain router.
+        local_ext_address = node_data.get("ExtAddress", "")
         network_name = node_data.get("NetworkName", "Unknown")
         num_routers = node_data.get("NumOfRouter", 0)
         state = node_data.get("State", "unknown")
+
+        # Fall back to the polled OTBR until a node claims leadership.
+        leader_ext_address = local_ext_address
 
         # Separate Thread and WiFi Matter devices
         thread_matter = [d for d in matter_devices if d["transport"] == "thread"]
@@ -505,7 +983,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Build nodes dictionary
         nodes: dict[str, dict] = {}
         router_index = 0
-        leader_ext_normalized = _normalize_address(leader_ext_address)
+        local_ext_normalized = _normalize_address(local_ext_address)
 
         for diag in diagnostics_data:
             ext_address = diag.get("ExtAddress", "")
@@ -515,7 +993,15 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Determine device role
             mode = diag.get("Mode", {})
             is_router = mode.get("DeviceType", 0) == 1
-            is_leader = ext_normalized == leader_ext_normalized
+            is_local_otbr = bool(local_ext_normalized) and ext_normalized == local_ext_normalized
+
+            # Current OTBR builds state outright which node holds leadership.
+            # Legacy builds do not, so assume the OTBR we polled is the leader,
+            # which is what this integration has always done.
+            diag_is_leader = diag.get("IsLeader")
+            is_leader = is_local_otbr if diag_is_leader is None else diag_is_leader
+            if is_leader:
+                leader_ext_address = ext_address
 
             if is_leader:
                 role = "leader"
@@ -532,7 +1018,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 claimed_ext_addresses.add(ext_normalized)
 
             # Get router identification (OUI lookup / custom_routers.yaml)
-            router_info = self._identify_router(ext_address, is_leader, router_index)
+            router_info = self._identify_router(ext_address, is_local_otbr, router_index)
             if role in ("leader", "router"):
                 router_index += 1
 

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -483,6 +483,10 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._router_index = 0  # Track router numbering
         self._custom_routers: list[dict[str, str]] = self._load_custom_routers()
         self._api_mode = API_MODE_UNKNOWN
+        # Last known Matter identity per node. A node's MAC and radio are
+        # stable facts, so remembering them keeps names on the map when
+        # matter-server is briefly unable to answer.
+        self._matter_node_cache: dict[int, dict[str, Any]] = {}
 
     def _load_custom_routers(self) -> list[dict[str, str]]:
         """Load user-defined border routers from custom_routers.yaml."""
@@ -828,7 +832,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # optional enrichment.
         except (KeyError, IndexError, StopIteration, AttributeError) as err:
             _LOGGER.debug("Matter client not available: %s", err)
-            return {}
+            return dict(self._matter_node_cache)
 
         async def fetch(node: Any) -> tuple[int, dict[str, Any]] | None:
             node_id = getattr(node, "node_id", None)
@@ -847,10 +851,17 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         results = await asyncio.gather(*(fetch(node) for node in nodes))
         by_node = {node_id: data for node_id, data in filter(None, results)}
 
+        # Keep what a node last told us. Otherwise a node that goes quiet for
+        # one update drops its extended address, and every name matched from
+        # it disappears from the map until it answers again.
+        self._matter_node_cache.update(by_node)
+        merged = dict(self._matter_node_cache)
+
         _LOGGER.debug(
-            "Matter diagnostics: %d/%d node(s) reported", len(by_node), len(nodes)
+            "Matter diagnostics: %d/%d node(s) reported, %d known in total",
+            len(by_node), len(nodes), len(merged),
         )
-        return by_node
+        return merged
 
     def _get_thread_border_routers(self) -> list[dict[str, Any]]:
         """Get Thread Border Routers from Home Assistant device registry."""

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -39,6 +39,7 @@ from .const import (
     ENDPOINT_DIAGNOSTICS,
     ENDPOINT_NODE,
     JSONAPI_SCAN_INTERVAL,
+    MATTER_NODE_TIMEOUT,
     REQUEST_TIMEOUT,
     ROUTING_ROLES,
     TASK_POLL_INTERVAL,
@@ -130,8 +131,38 @@ def _normalize_address(address: str) -> str:
     return address.replace(":", "").replace("-", "").replace(" ", "").upper()
 
 
+def _enum_value(value: Any) -> Any:
+    """Unwrap an Enum to its value, leaving plain values alone."""
+    return getattr(value, "value", value)
+
+
+def _parse_node_diagnostics(diagnostics: Any) -> dict[str, Any]:
+    """Pull what we need out of a matter-server NodeDiagnostics.
+
+    Read defensively: this crosses a library boundary, and the field holding the
+    IP list is spelled "ip_adresses" upstream - the kind of thing that gets
+    corrected without warning.
+    """
+    transport = _enum_value(getattr(diagnostics, "network_type", None))
+    transport = str(transport).lower() if transport is not None else TRANSPORT_UNKNOWN
+
+    node_type = _enum_value(getattr(diagnostics, "node_type", None))
+
+    addresses = getattr(diagnostics, "ip_adresses", None)
+    if addresses is None:
+        addresses = getattr(diagnostics, "ip_addresses", None)
+
+    return {
+        "transport": transport,
+        "mac_address": getattr(diagnostics, "mac_address", None),
+        "ip_addresses": list(addresses) if isinstance(addresses, (list, tuple)) else [],
+        "available": bool(getattr(diagnostics, "available", True)),
+        "node_type": str(node_type).lower() if node_type is not None else None,
+    }
+
+
 def _guess_transport(model: str | None, name: str | None, manufacturer: str | None) -> str:
-    """Guess a device's radio when its Matter node reported no interfaces.
+    """Guess a device's radio when matter-server reported nothing for the node.
 
     Deliberately never returns "thread". Assuming Thread by default is what put
     Wi-Fi bulbs into the mesh as Thread children; an honest "unknown" keeps them
@@ -488,7 +519,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             diagnostics_data = await self._fetch_diagnostics()
 
             # Get Matter devices from HA device registry
-            matter_devices = self._get_matter_devices()
+            matter_devices = await self._async_get_matter_devices()
 
             # Get Thread Border Routers from HA device registry
             thread_routers = self._get_thread_border_routers()
@@ -699,106 +730,17 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         raise OtbrTaskError(f"task '{label}' timed out after {TASK_TIMEOUT}s")
 
-    def _get_matter_devices(self) -> list[dict[str, Any]]:
+    async def _async_get_matter_devices(self) -> list[dict[str, Any]]:
         """Get Matter devices from Home Assistant device registry.
 
-        Also pulls each device's Thread Extended Address (EUI-64) and current
-        IPv6 addresses from matter-server's NodeDiagnostics, so that downstream
-        matching can use the actual hardware address instead of iteration order.
+        Each device is annotated with the radio it is actually on and, for
+        Thread devices, its extended address (EUI-64), so that downstream
+        matching can key on hardware identity rather than iteration order.
         """
         device_registry = dr.async_get(self.hass)
         matter_devices = []
 
-        # Build {node_id: (mac_address, [ip_addresses])} from matter-server, if available.
-        # We read this synchronously from cached cluster attributes rather than
-        # calling the async client.node_diagnostics(), because we're in a sync method.
-        node_info_by_id: dict[int, tuple[str | None, list[str]]] = {}
-        if _MATTER_AVAILABLE:
-            try:
-                # Lazy-import here so this module still imports if Matter integration
-                # is missing optional deps in some HA setups.
-                import base64  # noqa: PLC0415
-                from chip.clusters import Objects as Clusters  # noqa: PLC0415
-
-                matter_adapter = get_matter(self.hass)
-                attribute = Clusters.GeneralDiagnostics.Attributes.NetworkInterfaces
-                thread_iface_type = (
-                    Clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum.kThread
-                )
-                wifi_iface_type = (
-                    Clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum.kWiFi
-                )
-
-                for node in matter_adapter.matter_client.get_nodes():
-                    mac: str | None = None
-                    interfaces = node.get_attribute_value(
-                        0, cluster=None, attribute=attribute
-                    ) or []
-
-                    # Which radio the node actually uses. This is the device's
-                    # own report, and the only trustworthy source - guessing it
-                    # from model names put Wi-Fi bulbs in the Thread mesh.
-                    transport: str | None = None
-                    for iface in interfaces:
-                        if not getattr(iface, "isOperational", True):
-                            continue
-                        iface_type = getattr(iface, "type", None)
-                        if iface_type == thread_iface_type:
-                            transport = TRANSPORT_THREAD
-                            break
-                        if iface_type == wifi_iface_type and transport is None:
-                            transport = TRANSPORT_WIFI
-
-                    for iface in interfaces:
-                        # Find the operational Thread interface (or fall back to
-                        # any operational one if no Thread interface present).
-                        if not getattr(iface, "isOperational", True):
-                            continue
-                        hw_addr = getattr(iface, "hardwareAddress", None)
-                        if not hw_addr:
-                            continue
-                        # convert_mac_address logic: base64-decode if str, then
-                        # format as colon-separated hex.
-                        if isinstance(hw_addr, str):
-                            try:
-                                hw_addr = base64.b64decode(hw_addr)
-                            except (ValueError, TypeError):
-                                continue
-                        try:
-                            mac = ":".join(f"{b:02x}" for b in hw_addr)
-                        except (TypeError, ValueError):
-                            continue
-                        # Prefer the Thread interface if there is one; otherwise
-                        # take the first operational interface we find.
-                        if getattr(iface, "type", None) == thread_iface_type:
-                            break
-
-                    # IPs come from the same NetworkInterfaces struct.
-                    ips: list[str] = []
-                    for iface in interfaces:
-                        for ip_bytes in getattr(iface, "iPv6Addresses", []) or []:
-                            if isinstance(ip_bytes, str):
-                                try:
-                                    ip_bytes = base64.b64decode(ip_bytes)
-                                except (ValueError, TypeError):
-                                    continue
-                            # Format raw 16-byte IPv6 as standard string.
-                            if isinstance(ip_bytes, (bytes, bytearray)) and len(ip_bytes) == 16:
-                                import ipaddress  # noqa: PLC0415
-                                try:
-                                    ips.append(str(ipaddress.IPv6Address(bytes(ip_bytes))))
-                                except (ValueError, TypeError):
-                                    pass
-
-                    node_info_by_id[node.node_id] = (mac, ips, transport)
-            # IndexError covers get_matter() indexing into hass.data["matter"]
-            # before the Matter integration has finished setting up - a restart
-            # race that would otherwise fail the whole update over what is only
-            # optional enrichment.
-            except (
-                KeyError, IndexError, StopIteration, AttributeError, ImportError
-            ) as err:
-                _LOGGER.debug("Could not query Matter client for node diagnostics: %s", err)
+        diagnostics_by_node = await self._async_matter_node_diagnostics()
 
         for device in device_registry.devices.values():
             # Find the "matter" identifier on this device, if any.
@@ -814,28 +756,24 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # factory name, which is identical across two of the same product.
             name = device.name_by_user or device.name or "Unknown"
 
-            # Look up mac/IPs/transport by parsing the node ID out of the Matter
-            # identifier. HA stores it as e.g.
+            # Match the registry entry to its Matter node by parsing the node id
+            # out of the identifier, stored as
             # "deviceid_<fabric_hex>-<node_hex>-MatterNodeDevice".
-            mac_address: str | None = None
-            ip_addresses: list[str] = []
-            node_transport: str | None = None
+            diagnostics: dict[str, Any] = {}
             try:
-                # Strip the leading type prefix and split on dashes.
-                # node_id is the second hex segment.
                 stripped = matter_identifier_value
                 if stripped.startswith("deviceid_"):
                     stripped = stripped[len("deviceid_"):]
                 parts = stripped.split("-")
                 if len(parts) >= 2:
-                    node_id = int(parts[1], 16)
-                    if node_id in node_info_by_id:
-                        mac_address, ip_addresses, node_transport = node_info_by_id[node_id]
+                    diagnostics = diagnostics_by_node.get(int(parts[1], 16), {})
             except (ValueError, IndexError):
                 pass
 
-            # Prefer what the node reported; only guess if it told us nothing.
-            transport = node_transport or _guess_transport(
+            mac_address = diagnostics.get("mac_address")
+
+            # Only guess the radio if matter-server told us nothing at all.
+            transport = diagnostics.get("transport") or _guess_transport(
                 device.model, name, device.manufacturer
             )
 
@@ -846,10 +784,58 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "identifiers": list(device.identifiers),
                 "transport": transport,
                 "ext_address": _normalize_address(mac_address) if mac_address else None,
-                "ip_addresses": ip_addresses,
+                "ip_addresses": diagnostics.get("ip_addresses", []),
+                "available": diagnostics.get("available"),
+                "node_type": diagnostics.get("node_type"),
             })
 
         return matter_devices
+
+    async def _async_matter_node_diagnostics(self) -> dict[int, dict[str, Any]]:
+        """Ask matter-server for per-node diagnostics, keyed by node id.
+
+        This is the same source Home Assistant's own Matter device page uses.
+        An earlier implementation read GeneralDiagnostics.NetworkInterfaces from
+        cached cluster attributes to stay synchronous, but that attribute is
+        unreliable for battery powered sleepy end devices: their MAC address
+        came and went between updates, and every name matched from it went with
+        it. This method is async, which is what let us stop doing that.
+        """
+        if not _MATTER_AVAILABLE:
+            return {}
+
+        try:
+            matter_client = get_matter(self.hass).matter_client
+            nodes = list(matter_client.get_nodes())
+        # IndexError covers get_matter() indexing into hass.data["matter"]
+        # before the Matter integration has finished setting up - a restart
+        # race that would otherwise fail the whole update over what is only
+        # optional enrichment.
+        except (KeyError, IndexError, StopIteration, AttributeError) as err:
+            _LOGGER.debug("Matter client not available: %s", err)
+            return {}
+
+        async def fetch(node: Any) -> tuple[int, dict[str, Any]] | None:
+            node_id = getattr(node, "node_id", None)
+            if node_id is None:
+                return None
+            try:
+                diagnostics = await asyncio.wait_for(
+                    matter_client.node_diagnostics(node_id=node_id),
+                    timeout=MATTER_NODE_TIMEOUT,
+                )
+            except Exception as err:  # noqa: BLE001 - one node must not fail the update
+                _LOGGER.debug("No Matter diagnostics for node %s: %s", node_id, err)
+                return None
+            return node_id, _parse_node_diagnostics(diagnostics)
+
+        results = await asyncio.gather(*(fetch(node) for node in nodes))
+        by_node = {node_id: data for node_id, data in filter(None, results)}
+
+        _LOGGER.debug(
+            "Matter diagnostics: %d/%d node(s) reported", len(by_node), len(nodes)
+        )
+        return by_node
 
     def _get_thread_border_routers(self) -> list[dict[str, Any]]:
         """Get Thread Border Routers from Home Assistant device registry."""

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -826,7 +826,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return routers
 
     def _identify_router(
-        self, ext_address: str, is_local_otbr: bool, router_index: int
+        self, ext_address: str, is_local_otbr: bool
     ) -> dict[str, str]:
         """Identify a router by its extended address or characteristics.
 
@@ -891,23 +891,16 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "icon": "router",
                 }
 
-        # Generic fallback with numbering
-        router_names = [
-            ("Eero", "Amazon/Eero"),
-            ("Google Nest", "Google"),
-            ("Apple HomePod", "Apple"),
-            ("SmartThings", "Samsung"),
-            ("Thread Router", "Unknown"),
-        ]
-
-        # Cycle through router types based on index
-        name, manufacturer = router_names[router_index % len(router_names)]
-        if router_index > 0:
-            name = f"{name} #{router_index + 1}"
-
+        # Nothing identified it. Name the node after its own address instead of
+        # guessing a vendor: this used to pick one from a list by iteration
+        # order, so the first unrecognised router was labelled "Eero / Amazon"
+        # regardless of what it actually was. A wrong-but-confident label is
+        # worse than an honest one, and custom_routers.yaml exists to supply
+        # the real name.
+        suffix = ext_normalized[-4:] if ext_normalized else "unknown"
         return {
-            "name": name,
-            "manufacturer": manufacturer,
+            "name": f"Thread Router {suffix}",
+            "manufacturer": "Unknown",
             "type": "border_router",
             "icon": "router",
         }
@@ -988,7 +981,6 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Build nodes dictionary
         nodes: dict[str, dict] = {}
-        router_index = 0
         local_ext_normalized = _normalize_address(local_ext_address)
 
         for diag in diagnostics_data:
@@ -1024,9 +1016,7 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 claimed_ext_addresses.add(ext_normalized)
 
             # Get router identification (OUI lookup / custom_routers.yaml)
-            router_info = self._identify_router(ext_address, is_local_otbr, router_index)
-            if role in ("leader", "router"):
-                router_index += 1
+            router_info = self._identify_router(ext_address, is_local_otbr)
 
             # Override OUI-based name with Matter device name if we matched.
             if matter_self_match:

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -741,7 +741,13 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                                     pass
 
                     node_info_by_id[node.node_id] = (mac, ips)
-            except (KeyError, StopIteration, AttributeError, ImportError) as err:
+            # IndexError covers get_matter() indexing into hass.data["matter"]
+            # before the Matter integration has finished setting up - a restart
+            # race that would otherwise fail the whole update over what is only
+            # optional enrichment.
+            except (
+                KeyError, IndexError, StopIteration, AttributeError, ImportError
+            ) as err:
                 _LOGGER.debug("Could not query Matter client for node diagnostics: %s", err)
 
         for device in device_registry.devices.values():

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -131,6 +131,31 @@ def _normalize_address(address: str) -> str:
     return address.replace(":", "").replace("-", "").replace(" ", "").upper()
 
 
+def _matter_node_id(identifiers: Any) -> int | None:
+    """Find the Matter node id among a device's "matter" identifiers.
+
+    Home Assistant stores more than one: a
+    "deviceid_<fabric_hex>-<node_hex>-MatterNodeDevice" and a
+    "serial_<serial>". device.identifiers is a *set*, so reading whichever came
+    out first picked a different identifier between runs, and whenever it landed
+    on the serial - which carries no node id - the device silently lost its
+    diagnostics. That is what made Matter device identity flicker restart to
+    restart. Only the deviceid form is parsed, so a serial containing a dash
+    cannot be mistaken for one.
+    """
+    for value in identifiers:
+        if not isinstance(value, str) or not value.startswith("deviceid_"):
+            continue
+        parts = value[len("deviceid_"):].split("-")
+        if len(parts) < 2:
+            continue
+        try:
+            return int(parts[1], 16)
+        except ValueError:
+            continue
+    return None
+
+
 def _enum_value(value: Any) -> Any:
     """Unwrap an Enum to its value, leaving plain values alone."""
     return getattr(value, "value", value)
@@ -743,32 +768,22 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         diagnostics_by_node = await self._async_matter_node_diagnostics()
 
         for device in device_registry.devices.values():
-            # Find the "matter" identifier on this device, if any.
-            matter_identifier_value: str | None = None
-            for identifier in device.identifiers:
-                if identifier[0] == "matter":
-                    matter_identifier_value = identifier[1]
-                    break
-            if matter_identifier_value is None:
+            matter_identifiers = [
+                value for domain, value in device.identifiers if domain == "matter"
+            ]
+            if not matter_identifiers:
                 continue
 
             # Respect a name the user set in Home Assistant; device.name is the
             # factory name, which is identical across two of the same product.
             name = device.name_by_user or device.name or "Unknown"
 
-            # Match the registry entry to its Matter node by parsing the node id
-            # out of the identifier, stored as
-            # "deviceid_<fabric_hex>-<node_hex>-MatterNodeDevice".
-            diagnostics: dict[str, Any] = {}
-            try:
-                stripped = matter_identifier_value
-                if stripped.startswith("deviceid_"):
-                    stripped = stripped[len("deviceid_"):]
-                parts = stripped.split("-")
-                if len(parts) >= 2:
-                    diagnostics = diagnostics_by_node.get(int(parts[1], 16), {})
-            except (ValueError, IndexError):
-                pass
+            # Match the registry entry to its Matter node. Every matter
+            # identifier is considered, because they arrive in arbitrary order.
+            node_id = _matter_node_id(matter_identifiers)
+            diagnostics: dict[str, Any] = (
+                diagnostics_by_node.get(node_id, {}) if node_id is not None else {}
+            )
 
             mac_address = diagnostics.get("mac_address")
 

--- a/custom_components/thread_topology/coordinator.py
+++ b/custom_components/thread_topology/coordinator.py
@@ -100,11 +100,15 @@ KNOWN_BORDER_ROUTER_OUIS = {
     "40:22:D8": {"name": "ESP32 Thread", "manufacturer": "Espressif", "icon": "chip"},
 }
 
-# Fallback patterns for partial matches
-BORDER_ROUTER_PATTERNS = [
-    # Pattern, name, manufacturer
+# Fallback identification by how an extended address ends.
+#
+# Anchored to the end of the address, and kept long enough to mean something.
+# An earlier version matched these as substrings anywhere in the address and
+# included the bare "EA", which labels roughly one address in eighteen as an
+# Eero - and did, on hardware that was nothing of the sort.
+BORDER_ROUTER_ADDRESS_SUFFIXES = [
+    # Suffix, name, manufacturer
     ("EA17", "Eero", "Amazon/Eero"),
-    ("EA", "Eero", "Amazon/Eero"),  # Eero addresses often end with EA17
 ]
 
 
@@ -926,9 +930,9 @@ class ThreadTopologyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "icon": info.get("icon", "router"),
                     }
 
-        # Check for pattern matches in the address
-        for pattern, name, manufacturer in BORDER_ROUTER_PATTERNS:
-            if pattern in ext_normalized:
+        # Check for a known address suffix. Anchored, not a substring search.
+        for suffix, name, manufacturer in BORDER_ROUTER_ADDRESS_SUFFIXES:
+            if ext_normalized.endswith(suffix):
                 return {
                     "name": name,
                     "manufacturer": manufacturer,

--- a/custom_components/thread_topology/custom_routers.example.yaml
+++ b/custom_components/thread_topology/custom_routers.example.yaml
@@ -14,6 +14,10 @@
 #   - Partial match: "121BEC" (matches anywhere in the address)
 #
 # Icon options: chip, router, home-assistant, homepod, nest, eero, smartthings, nanoleaf, apple
+#
+# Entries here take precedence over every built-in guess, including the border
+# router this integration polls - which otherwise defaults to the name
+# "SkyConnect (OTBR)" whether or not that is what you actually run.
 
 routers:
   # Example: SMlight SLZB-06/07 border router

--- a/custom_components/thread_topology/manifest.json
+++ b/custom_components/thread_topology/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jjtortosa/thread-topology/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/thread_topology/manifest.json
+++ b/custom_components/thread_topology/manifest.json
@@ -4,6 +4,7 @@
   "codeowners": ["@jjtortosa"],
   "config_flow": true,
   "dependencies": [],
+  "after_dependencies": ["matter"],
   "documentation": "https://github.com/jjtortosa/thread-topology",
   "integration_type": "service",
   "iot_class": "local_polling",

--- a/custom_components/thread_topology/sensor.py
+++ b/custom_components/thread_topology/sensor.py
@@ -111,15 +111,16 @@ class ThreadTopologyMapSensor(CoordinatorEntity[ThreadTopologyCoordinator], Sens
             return {}
 
         data = self.coordinator.data
-        nodes = data.get("nodes", {})
         leader = data.get("leader_address", "")
-        matter = data.get("matter_devices", {})
 
         # Build topology text with device names
         lines = []
         lines.append(f"## 🧵 Thread Network: {data.get('network_name', 'Unknown')}")
         lines.append("")
         lines.append(f"**Routers:** {data.get('router_count', 0)} | **Thread Devices:** {data.get('total_devices', 0)}")
+
+        nodes = data.get("nodes", {})
+        matter = data.get("matter_devices", {})
 
         # Add Matter summary
         thread_count = len(matter.get("thread", []))
@@ -202,9 +203,6 @@ class ThreadTopologyMapSensor(CoordinatorEntity[ThreadTopologyCoordinator], Sens
 
         return {
             "topology_text": "\n".join(lines),
-            "nodes": nodes,
-            "matter_devices": matter,
-            "raw_data": data,
         }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,88 @@
 """Fixtures for Thread Topology tests."""
 from __future__ import annotations
 
+import json
+import sys
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+# --- Home Assistant stubs --------------------------------------------------
+# The integration is tested without Home Assistant installed. Most of HA can be
+# a MagicMock, but DataUpdateCoordinator is *subclassed*, and subclassing a
+# MagicMock silently turns the subclass into a mock too - every real method
+# then resolves to a mock instead of running. Give that one a real class.
+#
+# conftest is imported before any test module, so the sys.modules.setdefault
+# calls in the test modules themselves become no-ops and everyone shares these.
+
+
+class _StubUpdateFailed(Exception):
+    """Stand-in for homeassistant.helpers.update_coordinator.UpdateFailed."""
+
+
+class _StubDataUpdateCoordinator:
+    """Minimal stand-in exposing what the coordinator actually uses."""
+
+    def __init__(self, hass, logger, name=None, update_interval=None, **kwargs):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data = None
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+_update_coordinator_module = MagicMock()
+_update_coordinator_module.DataUpdateCoordinator = _StubDataUpdateCoordinator
+_update_coordinator_module.UpdateFailed = _StubUpdateFailed
+
+sys.modules.setdefault("homeassistant", MagicMock())
+sys.modules.setdefault("homeassistant.core", MagicMock())
+sys.modules.setdefault("homeassistant.config_entries", MagicMock())
+sys.modules.setdefault("homeassistant.const", MagicMock())
+sys.modules.setdefault("homeassistant.helpers", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.device_registry", MagicMock())
+sys.modules.setdefault(
+    "homeassistant.helpers.update_coordinator", _update_coordinator_module
+)
+
+
+@pytest.fixture(scope="session")
+def otbr_jsonapi_capture() -> dict:
+    """Return a real ot-br-posix JSON:API capture.
+
+    Taken from a live OTBR running the current REST API, with addresses and
+    network names anonymized. Structure is untouched - this exists so the
+    translation layer is tested against what OTBR actually sends rather than
+    what the docs imply it sends.
+    """
+    with (FIXTURE_DIR / "otbr_jsonapi_capture.json").open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.fixture
+def jsonapi_node_response(otbr_jsonapi_capture: dict) -> dict:
+    """Return the camelCase /node response from the live capture."""
+    return otbr_jsonapi_capture["node"]
+
+
+@pytest.fixture
+def jsonapi_devices_response(otbr_jsonapi_capture: dict) -> dict:
+    """Return the /api/devices collection from the live capture."""
+    return otbr_jsonapi_capture["devices"]
+
+
+@pytest.fixture
+def jsonapi_diagnostics_response(otbr_jsonapi_capture: dict) -> list:
+    """Return the per-router JSON:API diagnostic items from the live capture."""
+    return otbr_jsonapi_capture["diagnostics"]
 
 
 @pytest.fixture

--- a/tests/fixtures/otbr_jsonapi_capture.json
+++ b/tests/fixtures/otbr_jsonapi_capture.json
@@ -1,0 +1,303 @@
+{
+  "node": {
+    "baId": "00112233445566778899aabbccddeeff",
+    "baState": "",
+    "state": "router",
+    "routerCount": 2,
+    "rlocAddress": "fd00:1234:5678:9abc:0:ff:fe00:f800",
+    "extAddress": "0123456789abcdef",
+    "networkName": "ot-test-net",
+    "rloc16": "0xf800",
+    "routerId": 62,
+    "leaderData": {
+      "partitionId": 724038588,
+      "weighting": 64,
+      "dataVersion": 239,
+      "stableDataVersion": 43,
+      "leaderRouterId": 57
+    },
+    "extPanId": "1122334455667788"
+  },
+  "devices": {
+    "data": [
+      {
+        "id": "fedcba9876543210",
+        "type": "threadDevice",
+        "attributes": {
+          "extAddress": "fedcba9876543210",
+          "mlEidIid": "977fbefaca8117ef",
+          "omrIpv6Address": "fd00:abcd:ef01:1:7416:347:1d55:5dd",
+          "hostName": "",
+          "role": "router",
+          "mode": {
+            "deviceTypeFTD": true,
+            "rxOnWhenIdle": true,
+            "fullNetworkData": true
+          },
+          "created": "2026-01-01T00:00:00+00:00"
+        }
+      },
+      {
+        "id": "aabbccddeeff0011",
+        "type": "threadDevice",
+        "attributes": {
+          "extAddress": "aabbccddeeff0011",
+          "mlEidIid": "070cde43468c4246",
+          "omrIpv6Address": "fd00:abcd:ef01:1:5a77:32a0:2047:f45d",
+          "hostName": "",
+          "role": "child",
+          "mode": {
+            "deviceTypeFTD": false,
+            "rxOnWhenIdle": false,
+            "fullNetworkData": false
+          },
+          "created": "2026-01-01T00:00:00+00:00"
+        }
+      },
+      {
+        "id": "0123456789abcdef",
+        "type": "threadBorderRouter",
+        "attributes": {
+          "extAddress": "0123456789abcdef",
+          "mlEidIid": "b13ff757567249cf",
+          "omrIpv6Address": "fd00:abcd:ef01:1:195e:5e74:640c:5253",
+          "hostName": "",
+          "role": "router",
+          "mode": {
+            "deviceTypeFTD": true,
+            "rxOnWhenIdle": true,
+            "fullNetworkData": true
+          },
+          "baId": "00112233445566778899aabbccddeeff",
+          "baState": "active",
+          "state": "router",
+          "routerCount": 2,
+          "rlocAddress": "fd00:1234:5678:9abc:0:ff:fe00:f800",
+          "networkName": "ot-test-net",
+          "rloc16": "0xf800",
+          "routerId": 62,
+          "leaderData": {
+            "partitionId": 724038588,
+            "weighting": 64,
+            "dataVersion": 239,
+            "stableDataVersion": 43,
+            "leaderRouterId": 57
+          },
+          "extPanId": "1122334455667788",
+          "created": "2026-01-01T00:00:00+00:00",
+          "updated": "2026-01-01T00:00:00+00:00"
+        }
+      }
+    ],
+    "meta": {
+      "collection": {
+        "offset": 0,
+        "limit": 200,
+        "total": 3
+      }
+    }
+  },
+  "diagnostics": [
+    {
+      "id": "30762b3c-1d5e-4f90-849c-a7dc17c8d09c",
+      "type": "networkDiagnostics",
+      "attributes": {
+        "extAddress": "fedcba9876543210",
+        "rloc16": "0xe400",
+        "routerId": 57,
+        "mode": {
+          "rxOnWhenIdle": true,
+          "deviceTypeFTD": true,
+          "fullNetworkData": true
+        },
+        "connectivity": {
+          "parentPriority": 0,
+          "linkQuality3": 1,
+          "linkQuality2": 0,
+          "linkQuality1": 0,
+          "leaderCost": 0,
+          "idSequence": 152,
+          "activeRouters": 2,
+          "sedBufferSize": 1280,
+          "sedDatagramCount": 1
+        },
+        "route": {
+          "idSequence": 152,
+          "routeData": [
+            {
+              "routeId": 57,
+              "linkQualityOut": 0,
+              "linkQualityIn": 0,
+              "routeCost": 1
+            },
+            {
+              "routeId": 62,
+              "linkQualityOut": 3,
+              "linkQualityIn": 3,
+              "routeCost": 1
+            }
+          ]
+        },
+        "leaderData": {
+          "partitionId": 724038588,
+          "weighting": 64,
+          "dataVersion": 239,
+          "stableDataVersion": 43,
+          "leaderRouterId": 57
+        },
+        "ipv6Addresses": [
+          "fd00:abcd:ef01:1:7416:347:1d55:5dd",
+          "fd00:1234:5678:9abc:0:ff:fe00:fc00",
+          "fd00:1234:5678:9abc:0:ff:fe00:e400",
+          "fd00:1234:5678:9abc:977f:befa:ca81:17ef",
+          "fe80::fcdc:ba98:7654:3210"
+        ],
+        "childTable": [],
+        "children": [],
+        "routerNeighbors": [
+          {
+            "supportsErrorRate": true,
+            "rloc16": "0xf800",
+            "extAddress": "0123456789abcdef",
+            "version": 5,
+            "connectionTime": 822906,
+            "linkMargin": 49,
+            "averageRssi": -51,
+            "lastRssi": -52,
+            "frameErrorRate": 0.02671854756772518,
+            "messageErrorRate": 0.000976577401161194
+          }
+        ],
+        "isLeader": true,
+        "hostsService": false,
+        "isPrimaryBBR": false,
+        "isBorderRouter": false,
+        "created": "2026-01-01T00:00:00+00:00"
+      }
+    },
+    {
+      "id": "e065cac4-071d-4d3b-8424-bc01502760ba",
+      "type": "networkDiagnostics",
+      "attributes": {
+        "extAddress": "0123456789abcdef",
+        "rloc16": "0xf800",
+        "routerId": 62,
+        "mode": {
+          "rxOnWhenIdle": true,
+          "deviceTypeFTD": true,
+          "fullNetworkData": true
+        },
+        "connectivity": {
+          "parentPriority": 0,
+          "linkQuality3": 1,
+          "linkQuality2": 0,
+          "linkQuality1": 0,
+          "leaderCost": 1,
+          "idSequence": 152,
+          "activeRouters": 2,
+          "sedBufferSize": 1280,
+          "sedDatagramCount": 1
+        },
+        "route": {
+          "idSequence": 152,
+          "routeData": [
+            {
+              "routeId": 57,
+              "linkQualityOut": 3,
+              "linkQualityIn": 3,
+              "routeCost": 1
+            },
+            {
+              "routeId": 62,
+              "linkQualityOut": 0,
+              "linkQualityIn": 0,
+              "routeCost": 1
+            }
+          ]
+        },
+        "leaderData": {
+          "partitionId": 724038588,
+          "weighting": 64,
+          "dataVersion": 239,
+          "stableDataVersion": 43,
+          "leaderRouterId": 57
+        },
+        "ipv6Addresses": [
+          "fd00:1234:5678:9abc:0:ff:fe00:fc11",
+          "fd00:abcd:ef01:1:195e:5e74:640c:5253",
+          "fd00:1234:5678:9abc:0:ff:fe00:fc38",
+          "fd00:1234:5678:9abc:0:ff:fe00:fc10",
+          "fd00:1234:5678:9abc:0:ff:fe00:f800",
+          "fd00:1234:5678:9abc:b13f:f757:5672:49cf",
+          "fe80::0323:4567:89ab:cdef"
+        ],
+        "childTable": [
+          {
+            "childId": 2,
+            "timeout": 12,
+            "linkQuality": 2,
+            "mode": {
+              "rxOnWhenIdle": false,
+              "deviceTypeFTD": false,
+              "fullNetworkData": false
+            }
+          }
+        ],
+        "brCounters": {
+          "ifInUcastPkts": 3171,
+          "ifInBroadcastPkts": 0,
+          "ifOutUcastPkts": 6073,
+          "ifOutBroadcastPkts": 0,
+          "raRx": 1181,
+          "raTxSuccess": 942,
+          "raTxFailed": 0,
+          "rsRx": 688,
+          "rsTxSuccess": 3,
+          "rsTxFailed": 0
+        },
+        "children": [
+          {
+            "rxOnWhenIdle": false,
+            "deviceTypeFTD": false,
+            "fullNetworkData": false,
+            "cslSynchronized": false,
+            "supportsErrorRate": true,
+            "rloc16": "0xf802",
+            "childId": 2,
+            "extAddress": "aabbccddeeff0011",
+            "version": 5,
+            "timeout": 240,
+            "age": 3,
+            "connectionTime": 79054,
+            "supervisionInterval": 129,
+            "linkMargin": 18,
+            "averageRssi": -82,
+            "lastRssi": -84,
+            "frameErrorRate": 0.4621042311191559,
+            "messageErrorRate": 0.0776836797595024,
+            "queuedMessageCount": 0
+          }
+        ],
+        "routerNeighbors": [
+          {
+            "supportsErrorRate": true,
+            "rloc16": "0xe400",
+            "extAddress": "fedcba9876543210",
+            "version": 4,
+            "connectionTime": 84985,
+            "linkMargin": 51,
+            "averageRssi": -49,
+            "lastRssi": -50,
+            "frameErrorRate": 0,
+            "messageErrorRate": 0
+          }
+        ],
+        "isLeader": false,
+        "hostsService": true,
+        "isPrimaryBBR": true,
+        "isBorderRouter": true,
+        "created": "2026-01-01T00:00:01+00:00"
+      }
+    }
+  ]
+}

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -8,6 +8,7 @@ wrong in the same way the code did.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -349,6 +350,49 @@ class TestLocalOtbrNaming:
         result = coordinator._identify_router("fedcba9876543210", False, 0)
 
         assert result["name"] != "Pi 3B+ Border Router"
+
+
+class TestSvgWriting:
+    """The SVG write must stay off the event loop."""
+
+    def test_write_svg_creates_the_directory_and_file(self, coordinator, tmp_path):
+        www = tmp_path / "www"
+        coordinator.hass.config.path.return_value = str(www)
+
+        written = coordinator._write_svg("<svg/>")
+
+        assert Path(written) == www / "thread_topology.svg"
+        assert Path(written).read_text(encoding="utf-8") == "<svg/>"
+
+    def test_write_svg_tolerates_an_existing_directory(self, coordinator, tmp_path):
+        www = tmp_path / "www"
+        www.mkdir()
+        coordinator.hass.config.path.return_value = str(www)
+
+        assert coordinator._write_svg("<svg/>")
+
+    async def test_save_svg_delegates_to_the_executor(self, coordinator):
+        """Home Assistant warns if file I/O runs inline on the event loop."""
+        calls = []
+
+        async def fake_executor(func, *args):
+            calls.append((func, args))
+            return "/config/www/thread_topology.svg"
+
+        coordinator.hass.async_add_executor_job = fake_executor
+
+        result = await coordinator.save_svg_to_www({"nodes": {}})
+
+        assert result == "/local/thread_topology.svg"
+        assert calls and calls[0][0] == coordinator._write_svg
+
+    async def test_save_svg_survives_a_write_failure(self, coordinator):
+        async def failing_executor(func, *args):
+            raise OSError("read-only filesystem")
+
+        coordinator.hass.async_add_executor_job = failing_executor
+
+        assert await coordinator.save_svg_to_www({"nodes": {}}) is None
 
 
 class TestProcessTopologyStillHandlesLegacy:

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -7,8 +7,11 @@ wrong in the same way the code did.
 """
 from __future__ import annotations
 
+import asyncio
 import sys
+import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -27,6 +30,7 @@ from custom_components.thread_topology.coordinator import (  # noqa: E402
     ThreadTopologyCoordinator,
     _guess_transport,
     _link_margin_to_lqi,
+    _parse_node_diagnostics,
     _parse_rloc,
     _translate_child_table,
     _translate_diagnostic,
@@ -556,28 +560,195 @@ class TestEndDeviceMatching:
         ) is None
 
 
-class TestMatterQueryFailures:
-    """Matter data is optional enrichment; a failure must not fail the update.
+class TestParseNodeDiagnostics:
+    """Reading matter-server's NodeDiagnostics across a library boundary."""
 
-    The IndexError case is a real restart race: Home Assistant's get_matter()
-    indexes into hass.data["matter"], which is still empty if the Matter
-    integration has not finished setting up. It put the config entry into
-    setup_retry with "list index out of range".
+    @staticmethod
+    def _enum(value):
+        return SimpleNamespace(value=value)
+
+    def _diagnostics(self, **overrides):
+        base = SimpleNamespace(
+            node_id=87,
+            network_type=self._enum("thread"),
+            node_type=self._enum("sleepy_end_device"),
+            network_name="ha-thread-0d68",
+            ip_adresses=["fd00:1234:5678:9abc::5"],
+            mac_address="0a:79:9b:2b:d2:12:3f:8f",
+            available=True,
+        )
+        for key, value in overrides.items():
+            setattr(base, key, value)
+        return base
+
+    def test_unwraps_enums(self):
+        parsed = _parse_node_diagnostics(self._diagnostics())
+
+        assert parsed["transport"] == "thread"
+        assert parsed["node_type"] == "sleepy_end_device"
+
+    def test_accepts_a_plain_string_network_type(self):
+        parsed = _parse_node_diagnostics(self._diagnostics(network_type="wifi"))
+
+        assert parsed["transport"] == "wifi"
+
+    def test_reads_the_upstream_misspelled_ip_field(self):
+        """python-matter-server spells the field "ip_adresses"."""
+        parsed = _parse_node_diagnostics(self._diagnostics())
+
+        assert parsed["ip_addresses"] == ["fd00:1234:5678:9abc::5"]
+
+    def test_reads_the_field_if_upstream_corrects_the_spelling(self):
+        diagnostics = self._diagnostics()
+        del diagnostics.ip_adresses
+        diagnostics.ip_addresses = ["fd00::2"]
+
+        assert _parse_node_diagnostics(diagnostics)["ip_addresses"] == ["fd00::2"]
+
+    def test_mac_address_is_passed_through(self):
+        parsed = _parse_node_diagnostics(self._diagnostics())
+
+        assert parsed["mac_address"] == "0a:79:9b:2b:d2:12:3f:8f"
+
+    def test_availability_is_captured(self):
+        assert _parse_node_diagnostics(self._diagnostics(available=False))["available"] is False
+
+    def test_missing_fields_do_not_raise(self):
+        parsed = _parse_node_diagnostics(SimpleNamespace())
+
+        assert parsed["transport"] == "unknown"
+        assert parsed["mac_address"] is None
+        assert parsed["ip_addresses"] == []
+
+
+class TestMatterDeviceCollection:
+    """Building the Matter device list from matter-server diagnostics.
+
+    The sleepy end device below is the real failure this replaced: its MAC was
+    read from cached GeneralDiagnostics cluster attributes, which come and go
+    for battery devices, so the child's name flickered in and out of the map.
     """
 
-    @pytest.fixture
-    def matter_ready(self, coordinator, monkeypatch) -> ThreadTopologyCoordinator:
-        """Make the Matter branch reachable without Home Assistant installed."""
-        monkeypatch.setitem(sys.modules, "chip", MagicMock())
-        monkeypatch.setitem(sys.modules, "chip.clusters", MagicMock())
-        monkeypatch.setattr(coordinator_module, "_MATTER_AVAILABLE", True)
+    IDENTIFIER = "deviceid_9DEA92C0F9B67B5E-0000000000000057-MatterNodeDevice"
+    NODE_ID = 0x57
 
-        registry = MagicMock()
-        registry.devices.values.return_value = []
-        monkeypatch.setattr(
-            coordinator_module.dr, "async_get", lambda hass: registry
+    @pytest.fixture
+    def registry_device(self):
+        return SimpleNamespace(
+            identifiers={("matter", self.IDENTIFIER)},
+            name="BILRESA dual button",
+            name_by_user="Bedroom BILRESA button",
+            model="BILRESA dual button",
+            manufacturer="IKEA of Sweden",
         )
+
+    @pytest.fixture
+    def wired(self, coordinator, monkeypatch, registry_device):
+        monkeypatch.setattr(coordinator_module, "_MATTER_AVAILABLE", True)
+        registry = MagicMock()
+        registry.devices.values.return_value = [registry_device]
+        monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
         return coordinator
+
+    def _install_client(self, monkeypatch, node_diagnostics, node_ids=(NODE_ID,)):
+        client = MagicMock()
+        client.get_nodes.return_value = [
+            SimpleNamespace(node_id=node_id) for node_id in node_ids
+        ]
+        client.node_diagnostics = node_diagnostics
+        monkeypatch.setattr(
+            coordinator_module,
+            "get_matter",
+            lambda hass: SimpleNamespace(matter_client=client),
+            raising=False,
+        )
+
+    async def test_thread_device_is_fully_resolved(self, wired, monkeypatch):
+        async def node_diagnostics(node_id):
+            assert node_id == self.NODE_ID
+            return SimpleNamespace(
+                network_type=SimpleNamespace(value="thread"),
+                node_type=SimpleNamespace(value="sleepy_end_device"),
+                ip_adresses=["fd00::5"],
+                mac_address="0a:79:9b:2b:d2:12:3f:8f",
+                available=True,
+            )
+
+        self._install_client(monkeypatch, node_diagnostics)
+
+        devices = await wired._async_get_matter_devices()
+
+        assert len(devices) == 1
+        assert devices[0]["transport"] == "thread"
+        assert devices[0]["ext_address"] == "0A799B2BD2123F8F"
+        assert devices[0]["available"] is True
+
+    async def test_user_assigned_name_wins(self, wired, monkeypatch):
+        async def node_diagnostics(node_id):
+            return SimpleNamespace(
+                network_type=SimpleNamespace(value="thread"),
+                mac_address="0a:79:9b:2b:d2:12:3f:8f",
+            )
+
+        self._install_client(monkeypatch, node_diagnostics)
+
+        devices = await wired._async_get_matter_devices()
+
+        assert devices[0]["name"] == "Bedroom BILRESA button"
+
+    async def test_falls_back_when_a_node_reports_nothing(self, wired, monkeypatch):
+        """The device still appears, without an invented Thread membership."""
+        async def node_diagnostics(node_id):
+            raise RuntimeError("node unreachable")
+
+        self._install_client(monkeypatch, node_diagnostics)
+
+        devices = await wired._async_get_matter_devices()
+
+        assert len(devices) == 1
+        assert devices[0]["ext_address"] is None
+        assert devices[0]["transport"] == "unknown"
+
+    async def test_a_hanging_node_cannot_stall_the_update(self, wired, monkeypatch):
+        """node_diagnostics reaches over the network; it must be bounded."""
+        monkeypatch.setattr(coordinator_module, "MATTER_NODE_TIMEOUT", 0.05)
+
+        async def node_diagnostics(node_id):
+            await asyncio.sleep(30)
+
+        self._install_client(monkeypatch, node_diagnostics)
+
+        started = time.monotonic()
+        devices = await wired._async_get_matter_devices()
+        elapsed = time.monotonic() - started
+
+        # Unbounded, this would sit here for 30 seconds holding up the update.
+        assert elapsed < 5
+        assert len(devices) == 1
+        assert devices[0]["ext_address"] is None
+
+    async def test_one_slow_node_does_not_lose_the_others(self, wired, monkeypatch):
+        """Nodes are fetched concurrently, each with its own budget."""
+        monkeypatch.setattr(coordinator_module, "MATTER_NODE_TIMEOUT", 0.05)
+
+        async def node_diagnostics(node_id):
+            if node_id != self.NODE_ID:
+                await asyncio.sleep(30)
+            return SimpleNamespace(
+                network_type=SimpleNamespace(value="thread"),
+                mac_address="0a:79:9b:2b:d2:12:3f:8f",
+            )
+
+        self._install_client(
+            monkeypatch, node_diagnostics, node_ids=(0x99, self.NODE_ID, 0x98)
+        )
+
+        started = time.monotonic()
+        devices = await wired._async_get_matter_devices()
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 5
+        assert devices[0]["ext_address"] == "0A799B2BD2123F8F"
 
     @pytest.mark.parametrize(
         "error",
@@ -586,10 +757,10 @@ class TestMatterQueryFailures:
             KeyError("matter"),
             StopIteration(),
             AttributeError("adapter"),
-            ImportError("chip"),
         ],
     )
-    def test_survives_matter_client_errors(self, matter_ready, monkeypatch, error):
+    async def test_survives_matter_client_errors(self, wired, monkeypatch, error):
+        """get_matter() raced the Matter integration's setup and blew up."""
         monkeypatch.setattr(
             coordinator_module,
             "get_matter",
@@ -597,7 +768,19 @@ class TestMatterQueryFailures:
             raising=False,
         )
 
-        assert matter_ready._get_matter_devices() == []
+        devices = await wired._async_get_matter_devices()
+
+        assert len(devices) == 1
+        assert devices[0]["transport"] == "unknown"
+
+    async def test_no_matter_integration_at_all(self, coordinator, monkeypatch):
+        monkeypatch.setattr(coordinator_module, "_MATTER_AVAILABLE", False)
+        registry = MagicMock()
+        registry.devices.values.return_value = []
+        monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+        assert await coordinator._async_get_matter_devices() == []
+
 
 
 class TestSvgWriting:

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -22,6 +22,7 @@ sys.modules.setdefault("homeassistant.helpers", MagicMock())
 sys.modules.setdefault("homeassistant.helpers.device_registry", MagicMock())
 sys.modules.setdefault("homeassistant.helpers.update_coordinator", MagicMock())
 
+from custom_components.thread_topology import coordinator as coordinator_module  # noqa: E402
 from custom_components.thread_topology.coordinator import (  # noqa: E402
     ThreadTopologyCoordinator,
     _link_margin_to_lqi,
@@ -350,6 +351,50 @@ class TestLocalOtbrNaming:
         result = coordinator._identify_router("fedcba9876543210", False, 0)
 
         assert result["name"] != "Pi 3B+ Border Router"
+
+
+class TestMatterQueryFailures:
+    """Matter data is optional enrichment; a failure must not fail the update.
+
+    The IndexError case is a real restart race: Home Assistant's get_matter()
+    indexes into hass.data["matter"], which is still empty if the Matter
+    integration has not finished setting up. It put the config entry into
+    setup_retry with "list index out of range".
+    """
+
+    @pytest.fixture
+    def matter_ready(self, coordinator, monkeypatch) -> ThreadTopologyCoordinator:
+        """Make the Matter branch reachable without Home Assistant installed."""
+        monkeypatch.setitem(sys.modules, "chip", MagicMock())
+        monkeypatch.setitem(sys.modules, "chip.clusters", MagicMock())
+        monkeypatch.setattr(coordinator_module, "_MATTER_AVAILABLE", True)
+
+        registry = MagicMock()
+        registry.devices.values.return_value = []
+        monkeypatch.setattr(
+            coordinator_module.dr, "async_get", lambda hass: registry
+        )
+        return coordinator
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            IndexError("list index out of range"),
+            KeyError("matter"),
+            StopIteration(),
+            AttributeError("adapter"),
+            ImportError("chip"),
+        ],
+    )
+    def test_survives_matter_client_errors(self, matter_ready, monkeypatch, error):
+        monkeypatch.setattr(
+            coordinator_module,
+            "get_matter",
+            MagicMock(side_effect=error),
+            raising=False,
+        )
+
+        assert matter_ready._get_matter_devices() == []
 
 
 class TestSvgWriting:

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -30,6 +30,7 @@ from custom_components.thread_topology.coordinator import (  # noqa: E402
     ThreadTopologyCoordinator,
     _guess_transport,
     _link_margin_to_lqi,
+    _matter_node_id,
     _parse_node_diagnostics,
     _parse_rloc,
     _translate_child_table,
@@ -560,6 +561,48 @@ class TestEndDeviceMatching:
         ) is None
 
 
+class TestMatterNodeId:
+    """A Matter device carries several identifiers, in a set.
+
+    Reading "the first" one picked a different identifier between processes.
+    Whenever it landed on the serial, the device lost its diagnostics entirely -
+    which is what made names and Thread counts flicker across restarts.
+    """
+
+    DEVICE_ID = "deviceid_9DEA92C0F9B67B5E-0000000000000057-MatterNodeDevice"
+    SERIAL_ID = "serial_1035970000189A08"
+
+    def test_finds_the_node_id(self):
+        assert _matter_node_id([self.DEVICE_ID]) == 0x57
+
+    @pytest.mark.parametrize(
+        "identifiers",
+        [
+            (DEVICE_ID, SERIAL_ID),
+            (SERIAL_ID, DEVICE_ID),
+        ],
+    )
+    def test_order_does_not_matter(self, identifiers):
+        assert _matter_node_id(identifiers) == 0x57
+
+    def test_real_identifier_set(self):
+        """The set ordering is exactly what used to decide this."""
+        assert _matter_node_id({self.DEVICE_ID, self.SERIAL_ID}) == 0x57
+
+    def test_serial_alone_yields_nothing(self):
+        assert _matter_node_id([self.SERIAL_ID]) is None
+
+    def test_a_serial_containing_a_dash_is_not_parsed_as_a_node_id(self):
+        """Only the deviceid form is parsed, so this cannot be misread."""
+        assert _matter_node_id(["serial_ABC-DEF"]) is None
+
+    def test_unparseable_node_segment(self):
+        assert _matter_node_id(["deviceid_FABRIC-NOTHEX-MatterNodeDevice"]) is None
+
+    def test_no_identifiers(self):
+        assert _matter_node_id([]) is None
+
+
 class TestParseNodeDiagnostics:
     """Reading matter-server's NodeDiagnostics across a library boundary."""
 
@@ -630,12 +673,14 @@ class TestMatterDeviceCollection:
     """
 
     IDENTIFIER = "deviceid_9DEA92C0F9B67B5E-0000000000000057-MatterNodeDevice"
+    SERIAL = "serial_1035970000189A08"
     NODE_ID = 0x57
 
     @pytest.fixture
     def registry_device(self):
+        # Both identifiers, in a set, exactly as Home Assistant stores them.
         return SimpleNamespace(
-            identifiers={("matter", self.IDENTIFIER)},
+            identifiers={("matter", self.IDENTIFIER), ("matter", self.SERIAL)},
             name="BILRESA dual button",
             name_by_user="Bedroom BILRESA button",
             model="BILRESA dual button",

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -415,6 +415,42 @@ class TestUnidentifiedRouterNaming:
         assert result["manufacturer"] == "Apple"
 
 
+class TestAddressSuffixIdentification:
+    """Suffix matching must be anchored, not a substring search.
+
+    The rule was previously `"EA" in ext_address`, which labels roughly one
+    address in eighteen as an Eero.
+    """
+
+    def test_eero_suffix_is_identified(self, coordinator):
+        result = coordinator._identify_router("96308C2577D6EA17", False)
+
+        assert result["name"] == "Eero"
+        assert result["manufacturer"] == "Amazon/Eero"
+
+    def test_suffix_match_is_case_insensitive(self, coordinator):
+        assert coordinator._identify_router(
+            "96308c2577d6ea17", False
+        )["name"] == "Eero"
+
+    @pytest.mark.parametrize(
+        "ext_address",
+        [
+            "EA17000000000000",  # at the start
+            "0000EA1700000000",  # in the middle
+            "00000000000000EA",  # bare "EA" at the end
+            "12EA345678901234",  # bare "EA" in the middle
+            "6A57F823187E197B",  # the real leader on the dev network
+        ],
+    )
+    def test_unanchored_matches_are_rejected(self, coordinator, ext_address):
+        result = coordinator._identify_router(ext_address, False)
+
+        assert result["name"] != "Eero"
+        assert result["manufacturer"] != "Amazon/Eero"
+        assert result["name"].startswith("Thread Router ")
+
+
 class TestTransportGuess:
     """Fallback used only when a Matter node reports no interfaces."""
 

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -311,7 +311,7 @@ class TestLocalOtbrNaming:
     """custom_routers.yaml must be able to name the polled border router."""
 
     def test_defaults_to_skyconnect(self, coordinator):
-        result = coordinator._identify_router("0123456789abcdef", True, 0)
+        result = coordinator._identify_router("0123456789abcdef", True)
 
         assert result["name"] == "SkyConnect (OTBR)"
 
@@ -323,7 +323,7 @@ class TestLocalOtbrNaming:
             "icon": "chip",
         }]
 
-        result = coordinator._identify_router("0123456789abcdef", True, 0)
+        result = coordinator._identify_router("0123456789abcdef", True)
 
         assert result["name"] == "Pi 3B+ Border Router"
         assert result["manufacturer"] == "Raspberry Pi"
@@ -337,7 +337,7 @@ class TestLocalOtbrNaming:
         }]
 
         assert coordinator._identify_router(
-            "0123456789abcdef", True, 0
+            "0123456789abcdef", True
         )["name"] == "My OTBR"
 
     def test_other_routers_are_unaffected(self, coordinator):
@@ -348,9 +348,70 @@ class TestLocalOtbrNaming:
             "icon": "chip",
         }]
 
-        result = coordinator._identify_router("fedcba9876543210", False, 0)
+        result = coordinator._identify_router("fedcba9876543210", False)
 
         assert result["name"] != "Pi 3B+ Border Router"
+
+
+class TestUnidentifiedRouterNaming:
+    """An unrecognised router must not be given a made-up vendor.
+
+    The old fallback picked a name from a rotating list by iteration order, so
+    the first unidentified router became "Eero / Amazon-Eero" no matter what it
+    actually was - which is how an IKEA air quality monitor ended up presented
+    as an Eero on the topology map.
+    """
+
+    INVENTED = {"Eero", "Google Nest", "Apple HomePod", "SmartThings"}
+
+    def test_named_after_its_address(self, coordinator):
+        result = coordinator._identify_router("6a57f823187e197b", False)
+
+        assert result["name"] == "Thread Router 197B"
+
+    def test_manufacturer_is_not_invented(self, coordinator):
+        result = coordinator._identify_router("6a57f823187e197b", False)
+
+        assert result["manufacturer"] == "Unknown"
+
+    @pytest.mark.parametrize(
+        "ext_address",
+        [
+            "6a57f823187e197b",
+            "0011223344556677",
+            "ffffffffffffffff",
+            "1234567890abcdef",
+        ],
+    )
+    def test_no_address_yields_a_vendor_name(self, coordinator, ext_address):
+        result = coordinator._identify_router(ext_address, False)
+
+        assert result["name"] not in self.INVENTED
+        assert result["manufacturer"] not in {"Amazon/Eero", "Google", "Apple", "Samsung"}
+
+    def test_distinct_addresses_get_distinct_names(self, coordinator):
+        """Names come from the address, so they no longer depend on ordering."""
+        first = coordinator._identify_router("aaaaaaaaaaaa1111", False)["name"]
+        second = coordinator._identify_router("bbbbbbbbbbbb2222", False)["name"]
+
+        assert first != second
+
+    def test_same_address_is_stable_regardless_of_call_order(self, coordinator):
+        """The old rotation gave the same node different names run to run."""
+        coordinator._identify_router("cccccccccccc3333", False)
+        repeated = coordinator._identify_router("aaaaaaaaaaaa1111", False)["name"]
+        first = coordinator._identify_router("aaaaaaaaaaaa1111", False)["name"]
+
+        assert repeated == first
+
+    def test_empty_address_does_not_crash(self, coordinator):
+        assert coordinator._identify_router("", False)["name"]
+
+    def test_known_oui_still_wins(self, coordinator):
+        """Real identification must survive; only the invented fallback goes."""
+        result = coordinator._identify_router("286D970123456789", False)
+
+        assert result["manufacturer"] == "Apple"
 
 
 class TestMatterQueryFailures:

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -1,0 +1,385 @@
+"""Tests for the current ot-br-posix JSON:API REST support.
+
+These run against a real captured OTBR response (tests/fixtures), because the
+differences that broke this integration - renamed fields, hex-string RLOC16s,
+booleans where ints were - are exactly the ones a hand-written mock would get
+wrong in the same way the code did.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock homeassistant modules so coordinator can be imported without HA installed
+sys.modules.setdefault("homeassistant", MagicMock())
+sys.modules.setdefault("homeassistant.core", MagicMock())
+sys.modules.setdefault("homeassistant.config_entries", MagicMock())
+sys.modules.setdefault("homeassistant.const", MagicMock())
+sys.modules.setdefault("homeassistant.helpers", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.device_registry", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.update_coordinator", MagicMock())
+
+from custom_components.thread_topology.coordinator import (  # noqa: E402
+    ThreadTopologyCoordinator,
+    _link_margin_to_lqi,
+    _parse_rloc,
+    _translate_child_table,
+    _translate_diagnostic,
+    _translate_node,
+    _translate_route_data,
+)
+
+
+@pytest.fixture
+def coordinator() -> ThreadTopologyCoordinator:
+    """Return a coordinator with Home Assistant stubbed out."""
+    return ThreadTopologyCoordinator(MagicMock(), "http://otbr.invalid:8081")
+
+
+class TestParseRloc:
+    """RLOC16 arrives as a hex string now, but is used in arithmetic."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("0xf800", 0xF800),
+            ("0xF800", 0xF800),
+            ("f800", 0xF800),
+            (0xF800, 0xF800),
+            (0, 0),
+        ],
+    )
+    def test_parses(self, value, expected):
+        assert _parse_rloc(value) == expected
+
+    @pytest.mark.parametrize("value", [None, "", "   ", "not-hex", True, False])
+    def test_rejects(self, value):
+        assert _parse_rloc(value) is None
+
+
+class TestLinkMarginToLqi:
+    """Link margin to the 0-3 scale, for builds that only send neighbours."""
+
+    @pytest.mark.parametrize(
+        ("margin", "expected"),
+        [(49, 3), (20, 3), (19, 2), (10, 2), (9, 1), (2, 1), (1, 0), (0, 0)],
+    )
+    def test_thresholds(self, margin, expected):
+        assert _link_margin_to_lqi(margin) == expected
+
+    def test_missing_margin_is_zero(self):
+        assert _link_margin_to_lqi(None) == 0
+
+
+class TestTranslateNode:
+    """The /node route survived, but its field names did not."""
+
+    def test_camel_case_fields_are_mapped(self, jsonapi_node_response):
+        node = _translate_node(jsonapi_node_response)
+
+        assert node["NetworkName"] == "ot-test-net"
+        assert node["ExtAddress"] == "0123456789abcdef"
+        assert node["State"] == "router"
+
+    def test_num_of_router_was_renamed_to_router_count(self, jsonapi_node_response):
+        """NumOfRouter -> routerCount is a rename, not a case change."""
+        assert "NumOfRouter" not in jsonapi_node_response
+        assert _translate_node(jsonapi_node_response)["NumOfRouter"] == 2
+
+    def test_rloc16_becomes_an_int(self, jsonapi_node_response):
+        assert jsonapi_node_response["rloc16"] == "0xf800"
+        assert _translate_node(jsonapi_node_response)["Rloc16"] == 0xF800
+
+    def test_legacy_response_passes_through(self, mock_otbr_node_response):
+        """Old OTBR builds already speak PascalCase; do not disturb them."""
+        node = _translate_node(mock_otbr_node_response)
+
+        assert node["NetworkName"] == "MyHome1038137341"
+        assert node["NumOfRouter"] == 3
+        assert node["ExtAddress"] == "1EA5312CFB153F0B"
+        assert node["State"] == "leader"
+
+    def test_non_dict_is_safe(self):
+        assert _translate_node(None) == {}
+
+
+class TestTranslateDiagnostic:
+    """JSON:API diagnostic -> the legacy flat shape _process_topology reads."""
+
+    @pytest.fixture
+    def leader(self, jsonapi_diagnostics_response) -> dict:
+        return _translate_diagnostic(jsonapi_diagnostics_response[0])
+
+    @pytest.fixture
+    def border_router(self, jsonapi_diagnostics_response) -> dict:
+        return _translate_diagnostic(jsonapi_diagnostics_response[1])
+
+    def test_connectivity_is_translated(self, leader):
+        """Without this the link quality sensors all read zero."""
+        assert leader["Connectivity"]["LinkQuality3"] == 1
+        assert leader["Connectivity"]["LinkQuality2"] == 0
+        assert leader["Connectivity"]["LinkQuality1"] == 0
+
+    def test_leader_cost_is_translated(self, leader, border_router):
+        assert leader["Connectivity"]["LeaderCost"] == 0
+        assert border_router["Connectivity"]["LeaderCost"] == 1
+
+    def test_device_type_comes_from_device_type_ftd(self, leader):
+        """fullThreadDevice was renamed deviceTypeFTD; routers depend on it."""
+        assert leader["Mode"]["DeviceType"] == 1
+        assert leader["Mode"]["RxOnWhenIdle"] == 1
+
+    def test_mode_flags_are_ints_not_bools(self, leader):
+        """Legacy OTBR sent 0/1 and the downstream code compares against ints."""
+        for value in leader["Mode"].values():
+            assert isinstance(value, int)
+            assert not isinstance(value, bool)
+
+    def test_rloc16_is_an_int(self, leader, border_router):
+        assert leader["Rloc16"] == 0xE400
+        assert border_router["Rloc16"] == 0xF800
+
+    def test_route_data_is_pascal_case(self, border_router):
+        route_data = border_router["Route"]["RouteData"]
+
+        assert {"RouteId", "LinkQualityIn", "LinkQualityOut", "RouteCost"} <= set(
+            route_data[0]
+        )
+        assert any(entry["LinkQualityIn"] == 3 for entry in route_data)
+
+    def test_ipv6_addresses_are_mapped(self, leader):
+        assert leader["IP6AddressList"]
+        assert all(":" in address for address in leader["IP6AddressList"])
+
+    def test_leader_flag_is_captured(self, leader, border_router):
+        """OTBR states leadership outright rather than making us guess."""
+        assert leader["IsLeader"] is True
+        assert border_router["IsLeader"] is False
+
+    def test_border_router_flag_is_captured(self, leader, border_router):
+        assert border_router["IsBorderRouter"] is True
+        assert leader["IsBorderRouter"] is False
+
+    def test_child_table_is_translated(self, border_router):
+        children = border_router["ChildTable"]
+
+        assert len(children) == 1
+        assert children[0]["ChildId"] == 2
+        assert children[0]["Mode"]["RxOnWhenIdle"] == 0
+
+    def test_child_ext_address_is_preserved(self, border_router):
+        """children[] carries the ext address that childTable[] omits."""
+        assert border_router["ChildTable"][0]["ExtAddress"] == "aabbccddeeff0011"
+
+    def test_empty_child_table_is_omitted(self, leader):
+        assert "ChildTable" not in leader
+
+    def test_non_dict_is_safe(self):
+        assert _translate_diagnostic(None) == {}
+        assert _translate_diagnostic({"attributes": "nope"}) == {}
+
+
+class TestChildTableMerging:
+    """childTable[] and children[] overlap; both carry useful fields."""
+
+    def test_merges_by_child_id(self):
+        result = _translate_child_table({
+            "childTable": [{"childId": 2, "timeout": 12, "mode": {"rxOnWhenIdle": False}}],
+            "children": [{"childId": 2, "extAddress": "aabb", "rloc16": "0xf802"}],
+        })
+
+        assert len(result) == 1
+        assert result[0]["ExtAddress"] == "aabb"
+        assert result[0]["Timeout"] == 12
+        assert result[0]["Rloc16"] == 0xF802
+
+    def test_child_id_derived_from_rloc(self):
+        result = _translate_child_table({"children": [{"rloc16": "0xf802"}]})
+
+        assert result[0]["ChildId"] == 2
+
+    def test_children_only(self):
+        """children[] keeps its mode flags at the top level, not nested."""
+        result = _translate_child_table({
+            "children": [{"childId": 5, "rxOnWhenIdle": True, "deviceTypeFTD": False}],
+        })
+
+        assert result[0]["Mode"]["RxOnWhenIdle"] == 1
+        assert result[0]["Mode"]["DeviceType"] == 0
+
+    def test_missing_sources(self):
+        assert _translate_child_table({}) == []
+
+
+class TestRouteDataFallback:
+    """Some builds return routerNeighbors instead of a route table."""
+
+    def test_prefers_real_route_data(self):
+        result = _translate_route_data({
+            "route": {"routeData": [{"routeId": 7, "linkQualityIn": 2,
+                                     "linkQualityOut": 3, "routeCost": 1}]},
+            "routerNeighbors": [{"rloc16": "0xe400", "linkMargin": 49}],
+        })
+
+        assert result == [{"RouteId": 7, "LinkQualityIn": 2,
+                           "LinkQualityOut": 3, "RouteCost": 1}]
+
+    def test_synthesizes_from_router_neighbors(self):
+        result = _translate_route_data({
+            "routerNeighbors": [{"rloc16": "0xe400", "linkMargin": 49}],
+        })
+
+        assert result == [{"RouteId": 0xE400 >> 10, "LinkQualityIn": 3,
+                           "LinkQualityOut": 3, "RouteCost": 0}]
+
+    def test_no_route_information(self):
+        assert _translate_route_data({}) == []
+
+
+class TestProcessTopologyOnJsonApi:
+    """End to end: a live JSON:API capture must produce usable sensor data."""
+
+    @pytest.fixture
+    def topology(self, coordinator, jsonapi_node_response,
+                 jsonapi_diagnostics_response) -> dict:
+        return coordinator._process_topology(
+            _translate_node(jsonapi_node_response),
+            [_translate_diagnostic(item) for item in jsonapi_diagnostics_response],
+            [],
+            [],
+        )
+
+    def test_network_name(self, topology):
+        assert topology["network_name"] == "ot-test-net"
+
+    def test_router_count(self, topology):
+        assert topology["router_count"] == 2
+
+    def test_all_nodes_present(self, topology):
+        assert len(topology["nodes"]) == 2
+
+    def test_link_quality_is_not_zero(self, topology):
+        """The whole point: node sensors report a real LQI."""
+        qualities = [node["link_quality"] for node in topology["nodes"].values()]
+
+        assert qualities
+        assert all(quality == 3 for quality in qualities)
+
+    def test_exactly_one_leader(self, topology):
+        roles = [node["role"] for node in topology["nodes"].values()]
+
+        assert roles.count("leader") == 1
+
+    def test_leader_is_the_node_otbr_named(self, topology):
+        """The polled border router is a plain router here, not the leader."""
+        leader = next(
+            node for node in topology["nodes"].values() if node["role"] == "leader"
+        )
+
+        assert leader["ext_address"] == "fedcba9876543210"
+        assert topology["leader_address"] == "fedcba9876543210"
+
+    def test_no_node_is_an_end_device(self, topology):
+        """Both captured nodes are FTDs; Mode.DeviceType must survive."""
+        roles = {node["role"] for node in topology["nodes"].values()}
+
+        assert roles == {"leader", "router"}
+
+    def test_polled_otbr_keeps_its_border_router_name(self, topology):
+        local = topology["nodes"]["0123456789abcdef"]
+
+        assert local["role"] == "router"
+        assert local["manufacturer"] == "Nabu Casa"
+
+    def test_children_are_counted(self, topology):
+        assert sum(node["child_count"] for node in topology["nodes"].values()) == 1
+
+    def test_connections_are_built(self, topology):
+        assert any(node["connections"] for node in topology["nodes"].values())
+
+    def test_leader_cost_reaches_the_node(self, topology):
+        local = topology["nodes"]["0123456789abcdef"]
+
+        assert local["leader_cost"] == 1
+
+
+class TestLocalOtbrNaming:
+    """custom_routers.yaml must be able to name the polled border router."""
+
+    def test_defaults_to_skyconnect(self, coordinator):
+        result = coordinator._identify_router("0123456789abcdef", True, 0)
+
+        assert result["name"] == "SkyConnect (OTBR)"
+
+    def test_custom_router_overrides_the_default(self, coordinator):
+        coordinator._custom_routers = [{
+            "address": "0123456789ABCDEF",
+            "name": "Pi 3B+ Border Router",
+            "manufacturer": "Raspberry Pi",
+            "icon": "chip",
+        }]
+
+        result = coordinator._identify_router("0123456789abcdef", True, 0)
+
+        assert result["name"] == "Pi 3B+ Border Router"
+        assert result["manufacturer"] == "Raspberry Pi"
+
+    def test_custom_router_by_oui_prefix(self, coordinator):
+        coordinator._custom_routers = [{
+            "address": "012345",
+            "name": "My OTBR",
+            "manufacturer": "DIY",
+            "icon": "chip",
+        }]
+
+        assert coordinator._identify_router(
+            "0123456789abcdef", True, 0
+        )["name"] == "My OTBR"
+
+    def test_other_routers_are_unaffected(self, coordinator):
+        coordinator._custom_routers = [{
+            "address": "0123456789ABCDEF",
+            "name": "Pi 3B+ Border Router",
+            "manufacturer": "Raspberry Pi",
+            "icon": "chip",
+        }]
+
+        result = coordinator._identify_router("fedcba9876543210", False, 0)
+
+        assert result["name"] != "Pi 3B+ Border Router"
+
+
+class TestProcessTopologyStillHandlesLegacy:
+    """The legacy path must keep working on older OTBR builds."""
+
+    @pytest.fixture
+    def topology(self, coordinator, mock_otbr_node_response,
+                 mock_otbr_diagnostics_response) -> dict:
+        return coordinator._process_topology(
+            _translate_node(mock_otbr_node_response),
+            mock_otbr_diagnostics_response,
+            [],
+            [],
+        )
+
+    def test_network_name(self, topology):
+        assert topology["network_name"] == "MyHome1038137341"
+
+    def test_link_quality(self, topology):
+        assert all(
+            node["link_quality"] == 3 for node in topology["nodes"].values()
+        )
+
+    def test_leader_falls_back_to_the_polled_otbr(self, topology):
+        """No IsLeader flag on legacy builds, so the OTBR is assumed leader."""
+        leaders = [
+            address for address, node in topology["nodes"].items()
+            if node["role"] == "leader"
+        ]
+
+        assert leaders == ["1EA5312CFB153F0B"]
+
+    def test_total_devices(self, topology):
+        assert topology["total_devices"] == 7

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -8,6 +8,7 @@ wrong in the same way the code did.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import time
 from pathlib import Path
@@ -561,6 +562,27 @@ class TestEndDeviceMatching:
         ) is None
 
 
+class TestManifest:
+    """Startup ordering is declared in the manifest, not in code."""
+
+    @pytest.fixture
+    def manifest(self) -> dict:
+        path = (
+            Path(__file__).parent.parent
+            / "custom_components" / "thread_topology" / "manifest.json"
+        )
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_matter_is_set_up_first(self, manifest):
+        """Our first poll otherwise runs before Matter has any devices.
+
+        after_dependencies, not dependencies: Matter is optional enrichment and
+        the integration must still load without it.
+        """
+        assert "matter" in manifest["after_dependencies"]
+        assert "matter" not in manifest["dependencies"]
+
+
 class TestMatterNodeId:
     """A Matter device carries several identifiers, in a set.
 
@@ -817,6 +839,47 @@ class TestMatterDeviceCollection:
 
         assert len(devices) == 1
         assert devices[0]["transport"] == "unknown"
+
+    async def test_identity_survives_a_node_going_quiet(self, wired, monkeypatch):
+        """A node that misses one update must not lose its name on the map."""
+        async def answering(node_id):
+            return SimpleNamespace(
+                network_type=SimpleNamespace(value="thread"),
+                mac_address="0a:79:9b:2b:d2:12:3f:8f",
+            )
+
+        self._install_client(monkeypatch, answering)
+        first = await wired._async_get_matter_devices()
+        assert first[0]["ext_address"] == "0A799B2BD2123F8F"
+
+        async def silent(node_id):
+            raise RuntimeError("no answer")
+
+        self._install_client(monkeypatch, silent)
+        second = await wired._async_get_matter_devices()
+
+        assert second[0]["ext_address"] == "0A799B2BD2123F8F"
+        assert second[0]["transport"] == "thread"
+
+    async def test_identity_survives_matter_going_away(self, wired, monkeypatch):
+        async def answering(node_id):
+            return SimpleNamespace(
+                network_type=SimpleNamespace(value="thread"),
+                mac_address="0a:79:9b:2b:d2:12:3f:8f",
+            )
+
+        self._install_client(monkeypatch, answering)
+        await wired._async_get_matter_devices()
+
+        monkeypatch.setattr(
+            coordinator_module,
+            "get_matter",
+            MagicMock(side_effect=IndexError("list index out of range")),
+            raising=False,
+        )
+        devices = await wired._async_get_matter_devices()
+
+        assert devices[0]["ext_address"] == "0A799B2BD2123F8F"
 
     async def test_no_matter_integration_at_all(self, coordinator, monkeypatch):
         monkeypatch.setattr(coordinator_module, "_MATTER_AVAILABLE", False)

--- a/tests/test_jsonapi.py
+++ b/tests/test_jsonapi.py
@@ -25,6 +25,7 @@ sys.modules.setdefault("homeassistant.helpers.update_coordinator", MagicMock())
 from custom_components.thread_topology import coordinator as coordinator_module  # noqa: E402
 from custom_components.thread_topology.coordinator import (  # noqa: E402
     ThreadTopologyCoordinator,
+    _guess_transport,
     _link_margin_to_lqi,
     _parse_rloc,
     _translate_child_table,
@@ -412,6 +413,111 @@ class TestUnidentifiedRouterNaming:
         result = coordinator._identify_router("286D970123456789", False)
 
         assert result["manufacturer"] == "Apple"
+
+
+class TestTransportGuess:
+    """Fallback used only when a Matter node reports no interfaces."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "Smart Wi-Fi Dimmer Switch",   # TP-Link: the hyphen defeated "wifi"
+            "Smart WiFi Plug",
+            "Smart Wi Fi Bulb",
+        ],
+    )
+    def test_recognises_wifi_spellings(self, model):
+        assert _guess_transport(model, "Kitchen light", "TP-Link") == "wifi"
+
+    def test_recognises_wifi_only_manufacturers(self):
+        assert _guess_transport("Smart Lock", "Front door", "Nuki") == "wifi"
+
+    @pytest.mark.parametrize(
+        ("model", "manufacturer"),
+        [
+            ("Smart RGBTW Bulb", "Leedarson"),
+            ("ALPSTUGA air quality monitor", "IKEA of Sweden"),
+            ("Shelly 1 Mini Gen3", "Shelly"),
+            (None, None),
+        ],
+    )
+    def test_never_claims_thread_without_evidence(self, model, manufacturer):
+        """Defaulting to Thread is what put Wi-Fi bulbs in the mesh."""
+        assert _guess_transport(model, "Some device", manufacturer) != "thread"
+
+    def test_unrecognised_is_unknown(self):
+        assert _guess_transport("Smart RGBTW Bulb", "Light", "Leedarson") == "unknown"
+
+
+class TestEndDeviceMatching:
+    """Children are matched on identity, never by position."""
+
+    THREAD_BUTTON = {
+        "name": "Bedroom BILRESA button",
+        "model": "BILRESA dual button",
+        "manufacturer": "IKEA of Sweden",
+        "transport": "thread",
+        "ext_address": "AABBCCDDEEFF0011",
+        "ip_addresses": ["fd00:1234:5678:9abc::5"],
+    }
+    WIFI_BULB = {
+        "name": "Print Farm Light 1",
+        "model": "Smart RGBTW Bulb",
+        "manufacturer": "Leedarson",
+        "transport": "wifi",
+        "ext_address": None,
+        "ip_addresses": [],
+    }
+    UNKNOWN_DEVICE = {
+        "name": "Mystery device",
+        "model": None,
+        "manufacturer": None,
+        "transport": "unknown",
+        "ext_address": None,
+        "ip_addresses": [],
+    }
+
+    @pytest.fixture
+    def devices(self) -> list[dict]:
+        # Wi-Fi bulb first: it is what positional matching used to pick.
+        return [self.WIFI_BULB, self.UNKNOWN_DEVICE, self.THREAD_BUTTON]
+
+    def test_matches_on_child_ext_address(self, coordinator, devices):
+        match = coordinator._match_end_device(devices, set(), "0a799b2bd2123f8f")
+
+        assert match is None  # not this address
+
+        match = coordinator._match_end_device(devices, set(), "aabbccddeeff0011")
+
+        assert match["name"] == "Bedroom BILRESA button"
+
+    def test_ext_address_match_is_case_insensitive(self, coordinator, devices):
+        match = coordinator._match_end_device(devices, set(), "AA:BB:CC:DD:EE:FF:00:11")
+
+        assert match["name"] == "Bedroom BILRESA button"
+
+    def test_matches_on_shared_ipv6(self, coordinator, devices):
+        match = coordinator._match_end_device(
+            devices, set(), None, ["fd00:1234:5678:9abc::5"]
+        )
+
+        assert match["name"] == "Bedroom BILRESA button"
+
+    def test_unidentifiable_child_is_left_unnamed(self, coordinator, devices):
+        """Previously returned the first unclaimed device - a Wi-Fi bulb."""
+        assert coordinator._match_end_device(devices, set()) is None
+
+    def test_never_returns_a_non_thread_device(self, coordinator, devices):
+        for ext in (None, "ffffffffffffffff"):
+            match = coordinator._match_end_device(devices, set(), ext)
+            assert match is None or match["transport"] == "thread"
+
+    def test_claimed_devices_are_skipped(self, coordinator, devices):
+        claimed = {"AABBCCDDEEFF0011"}
+
+        assert coordinator._match_end_device(
+            devices, claimed, "aabbccddeeff0011"
+        ) is None
 
 
 class TestMatterQueryFailures:


### PR DESCRIPTION
## Problem

The README advertises "Smart Matching: Maps Thread extended addresses to 
Matter device names", but the current implementation in `_match_end_device`
(coordinator.py:332) and the child-matching loop in `_process_topology`
(coordinator.py:416) both use a positional index (`thread_device_idx`)
rather than comparing extended addresses. A code comment at line 340 even
acknowledges this:

    # Simple heuristic: assign devices based on order
    # In a real implementation, you'd need to query Matter fabric data

When OTBR's diagnostics response returns Thread nodes in a different order
than HA's device registry returns Matter devices, names get assigned to
the wrong nodes, or not at all. In my 4-device mesh, only 2 devices ever
got named correctly, and the "Router" node (an IKEA ALPSTUGA that routes
for sleepy children) stayed anonymous because its OUI isn't in the
hardcoded border-router table.

## Fix

1. Pull each Matter device's EUI-64 from 
   `Clusters.GeneralDiagnostics.NetworkInterfaces.hardwareAddress` via
   the matter-server client's cached cluster attributes (sync-safe).
2. Build a `{normalized_ext_address -> matter_device}` lookup map.
3. Match mesh nodes (router/leader) to Matter devices by normalized 
   ext_address — reliable, positional-order-independent.
4. For children (OTBR doesn't expose child ext_addresses in the standard
   ChildTable response), try IPv6 address overlap first, then fall back
   to "next unclaimed Thread Matter device". This is still best-effort,
   but no longer re-shuffles assignments on every poll.
5. Surface Matter Thread devices that aren't currently in the mesh via
   a new `unmatched_thread` list in the output, so the visualizer can
   show them as offline instead of dropping them silently.
6. Add a debug log summary of match counts per poll cycle.

## Backward compatibility

- `_match_end_device` signature changed (added `claimed_ext_addresses`
  and optional `child_ip6_addresses` params). It's a private method, so
  this shouldn't affect external callers.
- The Matter helpers import is wrapped in a try/except so the component
  still works if the Matter integration isn't installed (falls back to
  device-registry-only info, same as before).

## Tested with

- Home Assistant 2026.x
- python-matter-server `stable` (ghcr.io/home-assistant-libs/python-matter-server)
- OTBR via ownbee/hass-otbr-docker
- 5 IKEA Matter-over-Thread devices (ALPSTUGA air quality monitor, 2x 
  BILRESA dual buttons, Killippbok water sensor)
- Thread mesh with 1 OTBR leader and 1 routing Matter device

Before: 2 of 5 devices named (positional index coincidentally aligned 
for 2 of them).
After: all 4 online devices named correctly, 1 offline device surfaced
via the new unmatched list.